### PR TITLE
[feature] middleware

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,0 +1,6 @@
+import { signIn } from "@/auth"
+
+export async function GET(req: Request) {
+	const searchParams = new URL(req.url).searchParams;
+	return signIn('microsoft-entra-id', { redirectTo: searchParams.get('callbackUrl') ?? '/' });
+}

--- a/app/api/exams/route.ts
+++ b/app/api/exams/route.ts
@@ -1,5 +1,3 @@
-// TODO: Authenticate / Authorize this route to avoid anybody retreiving data.
-
 import { getAllExams } from "@/app/lib/database";
 
 export async function GET() {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { auth } from "@/auth"
+import { NextRequest, NextResponse } from 'next/server';
+ 
+export default async function middleware(req: NextRequest) {
+	const session = await auth();
+
+	if (!session?.user) {
+		const authUrl = new URL('/api/auth', req.url);
+		authUrl.searchParams.set('callbackUrl', req.url);
+		return NextResponse.redirect(authUrl);
+	}
+}
+
+// All routes require login, except /api/auth, that is used to login... (and some static Next.js things)
+export const config = {
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+}


### PR DESCRIPTION
Middleware requires authentication on all routes except `/api/auth` (that is used to log in)

So now, `/` and `/api/exams` can not be accessed if not logged in.