### PR TITLE
[fix] Duplicated exams

### DIFF
--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -52,7 +52,7 @@ export default function Calendar({ user }: CalendarProps) {
           end: e.crep_print_date ? e.crep_print_date.setHours(e.crep_print_date.getUTCHours() + 1) : currentEnd.toISOString().slice(0, 19), // TODO: Calculate the print duration by the number of pages
           description: e.name,
           durationEditable: false,
-          id: e.code,
+          id: e.id,
           status: e.crep_status,
           backgroundColor: eventColor,
           borderColor: eventColor,

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -50,7 +50,7 @@ export async function updateExamDateById(id: String, startDate: String, endDate:
     connection.connect()
 
     return new Promise(function(resolve, reject) {
-        connection.query('UPDATE crep SET crep_print_date = ? WHERE code = ?;', [startDate, id], (err, rows, fields) => {
+        connection.query('UPDATE crep SET crep_print_date = ? WHERE id = ?;', [startDate, id], (err, rows, fields) => {
             if (err) throw err
             resolve(JSON.stringify(rows));
         })
@@ -69,7 +69,7 @@ export async function updateExamStatusById(id: String, status: String) {
     connection.connect()
 
     return new Promise(function(resolve, reject) {
-        connection.query('UPDATE crep SET crep_status = ? WHERE code = ?;', [status, id], (err, rows, fields) => {
+        connection.query('UPDATE crep SET crep_status = ? WHERE id = ?;', [status, id], (err, rows, fields) => {
             if (err) throw err
             resolve(JSON.stringify(rows));
         })
@@ -88,7 +88,7 @@ export async function updateExamRemarkById(id: String, remark: String) {
     connection.connect()
 
     return new Promise(function(resolve, reject) {
-        connection.query('UPDATE crep SET crep_remark = ? WHERE code = ?;', [remark, id], (err, rows, fields) => {
+        connection.query('UPDATE crep SET crep_remark = ? WHERE id = ?;', [remark, id], (err, rows, fields) => {
             if (err) throw err
             resolve(JSON.stringify(rows));
         })


### PR DESCRIPTION
Using the exam code as a "unique id" was not a great idea... Now, it uses the real primary key `id` from the database.

This is needed because some exams (like the ones that have been done for multiple years) have the same code along the years.

close #30 