### PR TITLE
refactor: update exam status handling, add delivered status, update calendar max timeslots

### DIFF
--- a/app/components/Filters.tsx
+++ b/app/components/Filters.tsx
@@ -84,12 +84,7 @@ export function Filters({ examStatus, user, setFilters }: FiltersProps) {
     <Select
       isMulti
       name="colors"
-      options={
-        examStatus?.filter(
-          (status) =>
-            !status.needsAdmin || (user.isAdmin && status.needsAdmin)
-        )
-      }
+      options={examStatus}
       className="basic-multi-select z-10"
       classNamePrefix="select"
       placeholder="Filters..."

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -4,6 +4,7 @@ import React, { Dispatch, SetStateAction, useRef, useState } from "react";
 import { updateExamRemarkById, updateExamStatusById } from "../lib/database";
 import { EventInput, EventSourceInput } from "@fullcalendar/core/index.js";
 import { PrintButton } from "./print/ReactToPrint";
+import { examNotAdminStatus } from "../lib/examStatus";
 
 interface AppUser extends User {
     isAdmin?: boolean;
@@ -52,28 +53,26 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
             </button>
             {/* status selector for non-admin users. ToDo: Create a component instead?*/}
             <div id="status-selector" className="flex flex-row gap-4 flex-wrap">
-                {examStatus && examStatus.map((status) => (
-                    !status.needsAdmin && (
-                        <div key={status.value} id={status.value} className={`btn rounded-full border-2 border-solid border-${status.color} h-8 ${selectStatus === status.value ? `bg-${status.color} text-white` : "btn-secondary text-gray-800"}`} onClick={
-                            (e) => {
-                                const currentColor = examStatus?.find(s => s.value === selectStatus)?.color;
-                                // Remove previous color class from all siblings
-                                if (currentColor) {
-                                    e.currentTarget.parentElement?.childNodes.forEach((child) => {
-                                        if (child instanceof HTMLElement) {
-                                            child.classList.remove(currentColor ? `bg-${currentColor}` : "", "text-white");
-                                        }
-                                    });
-                                }
-                                // Add new color class to the clicked element and apply new status
-                                e.currentTarget.classList.add(`bg-${status.color}`, "text-white");
-                                setSelectStatus(status.value);
+                {examNotAdminStatus && examNotAdminStatus.map((status) => (
+                    <div key={status.value} id={status.value} className={`btn rounded-full border-2 border-solid border-${status.color} h-8 ${selectStatus === status.value ? `bg-${status.color} text-white` : "btn-secondary text-gray-800"}`} onClick={
+                        (e) => {
+                            const currentColor = examNotAdminStatus?.find(s => s.value === selectStatus)?.color;
+                            // Remove previous color class from all siblings
+                            if (currentColor) {
+                                e.currentTarget.parentElement?.childNodes.forEach((child) => {
+                                    if (child instanceof HTMLElement) {
+                                        child.classList.remove(currentColor ? `bg-${currentColor}` : "", "text-white");
+                                    }
+                                });
                             }
-                        }>
-                            <input className="hidden" type="radio" name="status" id={status.value} value={status.value} checked={selectStatus === status.value} />
-                            <label className="text-sm cursor-pointer" htmlFor={status.value}>{status.label}</label>
-                        </div>
-                    )
+                            // Add new color class to the clicked element and apply new status
+                            e.currentTarget.classList.add(`bg-${status.color}`, "text-white");
+                            setSelectStatus(status.value);
+                        }
+                    }>
+                        <input className="hidden" type="radio" name="status" id={status.value} value={status.value} checked={selectStatus === status.value} />
+                        <label className="text-sm cursor-pointer" htmlFor={status.value}>{status.label}</label>
+                    </div>
                 ))}
             </div>
             <div className="flex flex-row justify-between gap-x-12 flex-wrap gap-y-0 md:flex-nowrap sm:gap-y-2">
@@ -100,16 +99,14 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
             <div id="modal-toolbar" className="flex flex-row justify-between flex-wrap gap-y-0 xl:flex-nowrap sm:gap-y-2">
                 <div className="flex flex-row gap-4 flex-wrap gap-y-0 md:flex-nowrap sm:gap-y-2 ">
                     {/* ToDo : use a component */}
+                    {/* Displays a dropdown if user has admin privileges */}
                     {user.isAdmin && (
                         <select name="from" className="dropdown btn btn-secondary" id="from"
                             value={selectStatus}
                             onChange={(e) => setSelectStatus(e.target.value)}
                         >
-                            {/* Displays status according to admin privileges */}
                             {examStatus && examStatus.map((status) => (
-                                (!status.needsAdmin || user.isAdmin && status.needsAdmin) && (
-                                    <option key={status.value} value={status.value} className={status.color}>{status.label}</option>
-                                )
+                                <option key={status.value} value={status.value} className={status.color}>{status.label}</option>
                             ))}
                         </select>
                     )}

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -1,5 +1,6 @@
 'use server';
 import mysql from 'mysql2';
+import { examNotAdminStatus } from './examStatus';
 
 export async function getAllExams() {
     const connection = mysql.createConnection({
@@ -29,9 +30,9 @@ export async function getAllNonAdminExams() {
     })
 
     connection.connect()
-
+    
     return new Promise(function(resolve) {
-        connection.query('SELECT * from crep WHERE status IN ("toPrint", "printing", "finished");', (err, rows) => {
+        connection.query(`SELECT * from crep WHERE status IN (${examNotAdminStatus.map(obj => `"${obj.value}"`).join(", ")});`, (err, rows) => {
             if (err) throw err
             resolve(rows);
         })

--- a/app/lib/examStatus.ts
+++ b/app/lib/examStatus.ts
@@ -1,8 +1,12 @@
+// the safelist below is needed for Tailwind to generate the classes used for exam status:
+// bg-blue-500 bg-yellow-500 bg-green-500 bg-red-500 bg-gray-500 text-blue-500 text-yellow-500 text-green-500 text-red-500 text-gray-500 bg-violet-400 text-violet-400
+// border-blue-500 border-yellow-500 border-green-500 border-red-500 border-violet-400
 export const examStatus = [
     { value: 'registered', label: 'Registered', color: 'blue-500', hexColor: '#3b82f6', fcColor: 'oklch(62.3% 0.214 259.815)', needsAdmin: true },
     { value: 'toPrint', label: 'To Print', color: 'yellow-500', hexColor: '#eab308', fcColor: 'oklch(79.5% 0.184 86.047)', needsAdmin: false },
     { value: 'printing', label: 'Printing', color: 'green-500', hexColor: '#22c55e', fcColor: 'oklch(72.3% 0.219 149.579)', needsAdmin: false },
     { value: 'finished', label: 'Finished', color: 'red-500', hexColor: '#ef4444', fcColor: '#fb2c36', needsAdmin: false },
+    { value: 'delivered', label: 'Delivered', color: 'violet-400', hexColor: '#8b5cf6', fcColor: '#8b5cf6', needsAdmin: false },
     { value: 'canceled', label: 'Canceled', color: '', hexColor: '#020617', fcColor: '#000000', needsAdmin: true },
     { value: 'prep_teach', label: 'Prep-Teach', color: '', hexColor: '#020617', fcColor: '#000000', needsAdmin: true },
     { value: 'prep_2compile', label: 'Prep-2compile', color: '', hexColor: '#020617', fcColor: '#000000', needsAdmin: true },


### PR DESCRIPTION
Update status handling to use the new `examStatus` utils introduced in 9c3e7cd.
Add a new `delivered` status (closes #37) and expand calendar max time (closes #36)