### PR TITLE
Repro's textarea

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { User } from "next-auth";
 import React, { Dispatch, SetStateAction, useRef, useState } from "react";
-import { updateExamRemarkById, updateExamStatusById } from "../lib/database";
+import { updateExamRemarkById, updateExamStatusById, updateExamReproRemarkById } from "../lib/database";
 import { EventInput, EventSourceInput } from "@fullcalendar/core/index.js";
 import { PrintButton } from "./print/ReactToPrint";
 import { examNotAdminStatus } from "../lib/examStatus";
@@ -21,6 +21,7 @@ interface ModalProps {
 
 export function Modal({ event, shareLink, user, examStatus, exams, setExams }: ModalProps) {
     const [remark, setRemark] = useState(event?.extendedProps?.remark)
+    const [reproRemark, setReproRemark] = useState(event?.extendedProps?.reproRemark)
     const [selectStatus, setSelectStatus] = useState(event?.extendedProps?.status)
     const modalRef = useRef<HTMLFormElement | null>(null);
 
@@ -30,11 +31,15 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
             if (e.id == event?.id) {
                 e.remark = remark
                 e.status = selectStatus
+                e.reproRemark = reproRemark
             }
             return e;
         }) : [];
         await updateExamRemarkById(event.id || '', remark)
         setRemark(remark)
+
+        await updateExamReproRemarkById(event.id || '', reproRemark)
+        setReproRemark(reproRemark)
 
         await updateExamStatusById(event.id || '', selectStatus)
         setSelectStatus(selectStatus)
@@ -91,9 +96,15 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                 <label className="font-semibold w-full" htmlFor="description">Description</label>
                 <p className="description">{event?.extendedProps?.description}</p>
             </div>
-            <textarea className="remarks resize-none rounded-lg border border-gray-300 p-3" rows={12} name="remarks" id="remarks" placeholder="Add any remarks"
+            <textarea className="remarks resize-none rounded-lg border border-gray-300 p-3" rows={6} name="remarks" id="remarks" placeholder="Add any remarks"
                 value={remark || ""}
                 onChange={(e) => setRemark(e.target.value)}
+            >
+            </textarea>
+            <label className="font-semibold w-full" htmlFor="description">Repro's remark</label>
+            <textarea className="remarks resize-none rounded-lg border border-gray-300 p-3" rows={6} name="remarks" id="remarks" placeholder="Add any remarks"
+                value={reproRemark || ""}
+                onChange={(e) => setReproRemark(e.target.value)}
             >
             </textarea>
             <div id="modal-toolbar" className="flex flex-row justify-between flex-wrap gap-y-0 xl:flex-nowrap sm:gap-y-2">

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -56,7 +56,8 @@ export default function Calendar({ user }: CalendarProps) {
           status: e.status,
           backgroundColor: eventColor,
           borderColor: eventColor,
-          remark: e.remark
+          remark: e.remark,
+          reproRemark: e.repro_remark
         }
       })
       setExams(filteredData);
@@ -158,6 +159,7 @@ export default function Calendar({ user }: CalendarProps) {
           const clickedExam = Array.isArray(exams) ? exams.find((e: EventInput) => e.id == info.event.id) : undefined;
           info.event.setExtendedProp('status', clickedExam?.status);
           info.event.setExtendedProp('remark', clickedExam?.remark);
+          info.event.setExtendedProp('reproRemark', clickedExam?.reproRemark)
           setSelectedEvent(info.event as EventInput);
           // build the share link once and stash in state
           const rawPath = "vpsi1files.epfl.ch/CAPE/REPRO/TEST/" + info.event.extendedProps?.folder_name; //folder name doesn't exist yet. snippet from ludo. ToDo
@@ -195,7 +197,7 @@ export default function Calendar({ user }: CalendarProps) {
               ...ev,
               backgroundColor: color,
               borderColor: color,
-              extendedProps: { ...(ev.extendedProps || {}), status: ev.status, remark: ev.remark },
+              extendedProps: { ...(ev.extendedProps || {}), status: ev.status, remark: ev.remark, reproRemark: ev.reproRemark },
             };
           });
 

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -96,3 +96,22 @@ export async function updateExamRemarkById(id: string, remark: string) {
         connection.end()
     })
 }
+
+export async function updateExamReproRemarkById(id: string, reproRemark: string) {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    return new Promise(function(resolve) {
+        connection.query('UPDATE crep SET repro_remark = ? WHERE id = ?;', [reproRemark, id], (err, rows) => {
+            if (err) throw err
+            resolve(JSON.stringify(rows));
+        })
+        connection.end()
+    })
+}


### PR DESCRIPTION
This add a `textarea` under the one for global remarks, so that the Repro can write here what they thaught of the defined timing for the exam.

It also fixes an issue thrown by NextJS saying that we should use `defaultChecked` on input and not `checked` if we don't have an `onChange` handler.

closes #35 