### PR TITLE
[fix] Broken event date

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -84,12 +84,12 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                 <div className="date-input flex flex-row flex-wrap justify-between gap-y-1 [&_input]:rounded-sm">
                     <label className="font-semibold w-full" htmlFor="start">Start</label>
                     <input className="start-date basis-full xl:basis-auto" type="date" name="start" disabled defaultValue={event ? new Date(event.start as string).toISOString().split("T")[0] : ''} />
-                    <input className="start-time basis-full xl:basis-auto" type="time" name="start" disabled step="3600" min="00:00" max="23:59" defaultValue={event ? `${("0" + new Date(event.start as string).getHours()).slice(-2)}:${("0" + new Date(event.start as string).getMinutes()).slice(-2)}` : ''} />
+                    <input className="start-time basis-full xl:basis-auto" type="time" name="start" disabled step="3600" min="00:00" max="23:59" defaultValue={event ? `${("0" + (new Date(event.start as string).getHours() - 1)).slice(-2)}:${("0" + new Date(event.start as string).getMinutes()).slice(-2)}` : ''} />
                 </div>
                 <div className="date-input flex flex-row flex-wrap justify-between gap-y-1 [&_input]:rounded-lg">
                     <label className="font-semibold w-full" htmlFor="end">End</label>
                     <input className="end-date basis-full xl:basis-auto" type="date" name="end" disabled defaultValue={event ? new Date(event.end as string).toISOString().split("T")[0] : ''} />
-                    <input className="end-time basis-full xl:basis-auto" type="time" name="end" disabled step="3600" min="00:00" max="23:59" defaultValue={event ? `${("0" + new Date(event.end as string).getHours()).slice(-2)}:${("0" + new Date(event.end as string).getMinutes()).slice(-2)}` : ''} />
+                    <input className="end-time basis-full xl:basis-auto" type="time" name="end" disabled step="3600" min="00:00" max="23:59" defaultValue={event ? `${("0" + (new Date(event.end as string).getHours() - 1)).slice(-2)}:${("0" + new Date(event.end as string).getMinutes()).slice(-2)}` : ''} />
                 </div>
             </div>
             <div>

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -49,7 +49,7 @@ export default function Calendar({ user }: CalendarProps) {
         return {
           title: `${e.exam_code} - ${e.exam_name}`,
           start: e.print_date ? e.print_date.toISOString().slice(0, 19) : currentStart.toISOString().slice(0, 19), // TODO: Calculate the print duration by the number of pages
-          end: e.print_date ? e.print_date.setHours(e.print_date.getUTCHours() + 1) : currentEnd.toISOString().slice(0, 19), // TODO: Calculate the print duration by the number of pages
+          end: e.print_date ? new Date(e.print_date.setHours(e.print_date.getUTCHours() + 2)).toISOString().slice(0, 19) : currentEnd.toISOString().slice(0, 19), // TODO: Calculate the print duration by the number of pages
           description: e.exam_name,
           durationEditable: false,
           id: e.id,


### PR DESCRIPTION
`event.end` was `null`, which was causing the default unix date `01/01/1970`.

For the hours, for whatever reason, it was needed to take the event timestamp minus one hour... But it works now.

closes #51 