### PR TITLE
[feature] Basic Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+env:
+	cp /keybase/team/cepro_crep/secrets-dev.env .env
+
+up:
+	docker compose -f docker-compose-dev.yml up
+
+prod:
+	docker compose -f docker-compose-prod.yml up --build
+
+all: env up


### PR DESCRIPTION
`env`: Setting up the necessary .env file (access to the CREP keybase needed)
`up`: Run the docker-compose (dev file)
`prod`: Run the docker-compose (prod file, to make sure the image is ready to be pushed in production)
`all`: To just run the project in dev, using the previously mentioned `env` and `up` commands.