### PR TITLE
Refactor/printing coupon

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -144,6 +144,16 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                             }
                         </ul>
                     </div>
+                    <div className="date-input flex flex-row flex-wrap gap-4 gap-y-1 [&_input]:rounded-lg flex-1">
+                        <label className="font-semibold w-full" htmlFor="files">Files</label>
+                        <ul className={`${event?.extendedProps?.files.length > 0 && 'ml-6'} list-disc`}>
+                            {event?.extendedProps?.files.length > 0 ? 
+                                event?.extendedProps?.files.map((file:string) => (
+                                    <li key={file}>{file}</li>
+                                )) : 'None'
+                            }
+                        </ul>
+                    </div>
                 </div>
             </div>
             <div>

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -74,7 +74,8 @@ export default function Calendar({ user }: CalendarProps) {
           paperColor: e.paper_color,
           needScan: e.need_scan,
           contact: e.contact,
-          authorizedPersons: e.authorized_persons
+          authorizedPersons: e.authorized_persons,
+          files: e.files
         }
       })
       setExams(filteredData);
@@ -191,6 +192,7 @@ export default function Calendar({ user }: CalendarProps) {
           info.event.setExtendedProp('needScan', clickedExam?.needScan)
           info.event.setExtendedProp('contact', clickedExam?.contact)
           info.event.setExtendedProp('authorizedPersons', JSON.parse(clickedExam?.authorizedPersons)) // Necessary since it's an Array of objects.
+          info.event.setExtendedProp('files', JSON.parse(clickedExam?.files)) // Necessary since it's an Array of strings.
           setSelectedEvent(info.event as EventInput);
           // build the share link once and stash in state
           const rawPath = "vpsi1files.epfl.ch/CAPE/REPRO/TEST/" + info.event.extendedProps?.folder_name; //folder name doesn't exist yet. snippet from ludo. ToDo

--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -341,6 +341,8 @@ export default function App({ user }: RegisterProps) {
                 }
             }
 
+            const filesNamesArray = selectedFiles.map((file) => file.name)
+
             const insertedExam = await insertExamForPrint(
                 {
                     exam_name: exam_name,
@@ -360,6 +362,7 @@ export default function App({ user }: RegisterProps) {
                     registered_by: user.email || '',
                     need_scan: data.needScan,
                     financial_center: data.financialCenter,
+                    files: JSON.stringify(filesNamesArray),
                 }
             )
 

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -215,6 +215,7 @@ export async function insertExamForPrint(exam: {
     registered_by: string;
     need_scan: boolean;
     financial_center: string;
+    files: string;
 }): Promise<number> {
     const connection = mysql.createConnection({
         host: process.env.MYSQL_HOST,
@@ -226,7 +227,7 @@ export async function insertExamForPrint(exam: {
     connection.connect();
 
     return new Promise((resolve, reject) => {
-        const sql = `INSERT INTO crep (exam_code, exam_date, exam_name, exam_pages, exam_students, print_date, paper_format, paper_color, contact, authorized_persons, remark, repro_remark, status, registered_by, need_scan, financial_center) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
+        const sql = `INSERT INTO crep (exam_code, exam_date, exam_name, exam_pages, exam_students, print_date, paper_format, paper_color, contact, authorized_persons, remark, repro_remark, status, registered_by, need_scan, financial_center, files) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
 
         const params = [
             exam.exam_code,
@@ -244,7 +245,8 @@ export async function insertExamForPrint(exam: {
             exam.status || 'registered',
             exam.registered_by,
             exam.need_scan,
-            exam.financial_center
+            exam.financial_center,
+            exam.files
         ];
 
         connection.query(sql, params, (err, result) => {


### PR DESCRIPTION
Refactoring the Modal (that indeed creates the printing coupon), adding the missing information that was needed.
(Financial center, exam date, paper format, paper color, files, authorized persons, ...)

This PR also adds a `files` column in the database.
Work for the new column has already been done in [CREP.ops](https://github.com/EPFL-CePro/CREP.ops/commit/41c3305da60bab6ca8c488e127a35216a53c8c4e).

close #24 