### PR TITLE
[feature] Desired delivery date in database & on printing coupon

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -167,6 +167,12 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                         </ul>
                     </div>
                 </div>
+                <div className="flex flex-row justify-between gap-x-12 flex-wrap gap-y-0 md:flex-nowrap sm:gap-y-2 items-start">
+                    <div className="date-input flex flex-row flex-wrap gap-4 gap-y-1 [&_input]:rounded-sm flex-1">
+                        <label className="font-semibold w-full" htmlFor="desiredDate">Desired delivery date</label>
+                        <input className="exam-date basis-full xl:basis-auto" type="date" name="desiredDate" disabled defaultValue={formatDateOnlyValue(event?.extendedProps?.desiredDate as string | Date | null | undefined)} />
+                    </div>
+                </div>
             </div>
             <div>
                 <label className="font-semibold w-full" htmlFor="description">Description</label>

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -82,7 +82,8 @@ export default function Calendar({ user }: CalendarProps) {
           needScan: e.need_scan,
           contact: e.contact,
           authorizedPersons: e.authorized_persons,
-          files: e.files
+          files: e.files,
+          desiredDate: e.desired_date,
         }
       })
       setExams(filteredData);
@@ -188,6 +189,7 @@ export default function Calendar({ user }: CalendarProps) {
           info.event.setExtendedProp('contact', clickedExam?.contact)
           info.event.setExtendedProp('authorizedPersons', JSON.parse(clickedExam?.authorizedPersons)) // Necessary since it's an Array of objects.
           info.event.setExtendedProp('files', JSON.parse(clickedExam?.files)) // Necessary since it's an Array of strings.
+          info.event.setExtendedProp('desiredDate', clickedExam?.desiredDate)
           setSelectedEvent(info.event);
           // build the share link once and stash in state
           const rawPath = "vpsi1files.epfl.ch/CAPE/REPRO/TEST/" + info.event.extendedProps?.folder_name; //folder name doesn't exist yet. snippet from ludo. ToDo

--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -353,6 +353,7 @@ export default function App({ user }: RegisterProps) {
                     need_scan: data.needScan,
                     financial_center: data.financialCenter,
                     files: JSON.stringify(filesNamesArray),
+                    desired_date: data.desiredDate,
                 }
             )
 

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -182,6 +182,7 @@ export async function insertExamForPrint(exam: {
     need_scan: boolean;
     financial_center: string;
     files: string;
+    desired_date: string | Date;
 }): Promise<number> {
     const connection = mysql.createConnection({
         host: process.env.MYSQL_HOST,
@@ -193,7 +194,7 @@ export async function insertExamForPrint(exam: {
     connection.connect();
 
     return new Promise((resolve, reject) => {
-        const sql = `INSERT INTO crep (exam_code, exam_date, exam_name, exam_pages, exam_students, print_date, paper_format, paper_color, contact, authorized_persons, remark, repro_remark, status, registered_by, need_scan, financial_center, files) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
+        const sql = `INSERT INTO crep (exam_code, exam_date, exam_name, exam_pages, exam_students, print_date, paper_format, paper_color, contact, authorized_persons, remark, repro_remark, status, registered_by, need_scan, financial_center, files, desired_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
 
         const params = [
             exam.exam_code,
@@ -212,7 +213,8 @@ export async function insertExamForPrint(exam: {
             exam.registered_by,
             exam.need_scan,
             exam.financial_center,
-            exam.files
+            exam.files,
+            exam.desired_date
         ];
 
         connection.query(sql, params, (err, result) => {


### PR DESCRIPTION
Desired delivery is now stored in database and displayed in the modal & printing coupon.
Necessary changes have also been made in [CREP.ops](https://github.com/EPFL-CePro/CREP.ops/commit/a9f84db0f728aa0f10200fca01c187bafb52be08)

fix #111 