### PR TITLE
[feature] `registered-warning` and `registered-error`

### DIFF
--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -150,6 +150,8 @@ export default function App({ user }: RegisterProps) {
         // validate that desiredDate is not later than examDate
         const { examDate, desiredDate } = data;
 
+        var status = 'registered';
+
         if (!data.course) {
             openModal("Course Selection Error", "Please select a course.");
             return;
@@ -166,6 +168,7 @@ export default function App({ user }: RegisterProps) {
                 if (!confirmed) {
                     return;
                 }
+                status = 'registered-warning'
             }
             else {
                 // clear any previous date error
@@ -331,6 +334,15 @@ export default function App({ user }: RegisterProps) {
                 }
             }
 
+            /* If `printingDate` is undefined, that means that a printing schedule can not be defined.
+            (timings are too short, already existing planning is too full, ...)
+            So we should register it at 07:00 AM on the desired delivery date, with the status `registered-error`. */
+            if(!printingDate) {
+                desiredDate.setHours(7)
+                printingDate = formatDateTimeForDatabase(desiredDate);
+                status = 'registered-error'
+            }
+
             const filesNamesArray = selectedFiles.map((file) => file.name)
 
             const insertedExam = await insertExamForPrint(
@@ -348,7 +360,7 @@ export default function App({ user }: RegisterProps) {
                     paper_color: data.paperColor,
                     remark: data.remark,
                     repro_remark: null,
-                    status: 'registered',
+                    status: status,
                     registered_by: user.email || '',
                     need_scan: data.needScan,
                     financial_center: data.financialCenter,
@@ -380,19 +392,28 @@ export default function App({ user }: RegisterProps) {
                 openModal("File Upload Error", "An error occurred while uploading exam files. Please try again.");
                 return;
             }
-            const daysBetweenExamAndDesired = businessDaysBetween(data.desiredDate, data.examDate)
-            const lessThanEightDays = daysBetweenExamAndDesired < 8;
+           /*
+            The mail checks if status is `registered-warning` or `registered-error`, and displays a message for the user and the CePro team to let them know about the exam printing situation.
+            If the status is `registered-warning`, that means that a printing schedule could be found, but that the timing is too short (less than 8 days between the exam date and the desired delivery date)
+            If the status is `registered-error`, that means that a printing schedule could NOT be found, so the CePro (and Repro) team need to do something for the user. 
+           */
             if (process.env.NODE_ENV !== "development") {
                 await sendMail(
                     user.email || '',
-                    `${lessThanEightDays ? 'REQUIRES ATTENTION - ' : ''} CePro - Exam printing service subscription confirmation`,
+                    `${status == 'registered-warning' || status == 'registered-error' ? 'REQUIRES ATTENTION - ' : ''} CePro - Exam printing service subscription confirmation`,
                     `
 Hello,
-Your subscription to our exam printing service has been successfully registered:
+Your subscription to our exam printing service has been registered:
 
-${lessThanEightDays ? `⚠️ : We would like to inform you that you choose a desired delivery date that is inferior to 8 business days before the exam.
+${['registered-warning', 'registered-error'].includes(status) ? `
+⚠️ : ${
+    status === 'registered-error'
+        ? `Due to a printing planning extremely full or too tight delays, we could not determine a printing session for your exam.
+The CePro team will get in touch with you as soon as possible to discuss about your situation.`
+        : `We would like to inform you that you choose a desired delivery date that is inferior to 8 business days before the exam.
 The CePro team will get in touch with you shortly to discuss about your situation.
-Next time, please register to the printing service earlier to make sur that the printing team has the right amount of time to print your exam correctly.
+Next time, please register to the printing service earlier to make sur that the printing team has the right amount of time to print your exam correctly.`
+}
 ` : ''}
 
 - Course: ${data.course?.label}
@@ -404,7 +425,23 @@ ${data.remark && `- Additional remarks: ${data.remark}`}`,
                     'cepro-exams@epfl.ch'
                 );
             }
-            openModal("Registration Successful", 'Your Exam ' + exam_code + ' has been registered and a confirmation has been sent to your email.');
+            if(status == 'registered-warning') {
+                // Modal with warning that there is less than 8 days between the exam date and the desired delivery date.
+                openModal("REQUIRES ATTENTION - Registration Successful", `
+                    Your exam ${exam_code} has been registered, but with a delivery date that is inferior to 8 business days before the exam.
+                    An email has been sent to you as a confirmation.
+                    The CePro team can contact you at any time to discuss about your situation.
+                `)
+            } else if(status == 'registered-error') {
+                // Modal with error message that a printing session could not be calculated and that the CePro team will contact the user as soon as possible.
+                openModal("REQUIRES ATTENTION - REGISTRATION ERROR", `
+                    You filled the form correctly, but due to a printing planning extremely full or too tight delays, we could not determine a printing session for your exam.
+                    The CePro team will contact you as soon as possible to discuss about your situation.
+                    An email has been sent to you and the CePro team as information.
+                `)
+            } else {
+                openModal("Registration Successful", 'Your Exam ' + exam_code + ' has been registered and a confirmation has been sent to your email.');
+            }
             reset();
         } catch (err) {
             console.error(err);

--- a/app/lib/examStatus.ts
+++ b/app/lib/examStatus.ts
@@ -3,9 +3,11 @@
 // border-blue-500 border-yellow-500 border-green-500 border-red-500 border-violet-400
 export const examStatus = [
     { value: 'registered', label: 'Registered', color: 'blue-500', hexColor: '#3b82f6', fcColor: 'oklch(62.3% 0.214 259.815)', needsAdmin: true },
+    { value: 'registered-warning', label: 'Registered-Warning', color: 'orange-500', hexColor: '#e38402', fcColor: 'oklch(0.7 0.1599 62.49)', needsAdmin: true },
+    { value: 'registered-error', label: 'Registered-Error', color: 'red-500', hexColor: '#ef4444', fcColor: '#fb2c36', needsAdmin: true },
     { value: 'toPrint', label: 'To Print', color: 'yellow-500', hexColor: '#eab308', fcColor: 'oklch(79.5% 0.184 86.047)', needsAdmin: false },
     { value: 'printing', label: 'Printing', color: 'green-500', hexColor: '#22c55e', fcColor: 'oklch(72.3% 0.219 149.579)', needsAdmin: false },
-    { value: 'finished', label: 'Finished', color: 'red-500', hexColor: '#ef4444', fcColor: '#fb2c36', needsAdmin: false },
+    { value: 'finished', label: 'Finished', color: 'gray-500', hexColor: '#6a7282', fcColor: 'oklch(0.551 0.0267 264.33)', needsAdmin: false },
     { value: 'delivered', label: 'Delivered', color: 'violet-400', hexColor: '#8b5cf6', fcColor: '#8b5cf6', needsAdmin: false },
     { value: 'canceled', label: 'Canceled', color: '', hexColor: '#020617', fcColor: '#000000', needsAdmin: true },
     { value: 'prep_teach', label: 'Prep-Teach', color: '', hexColor: '#020617', fcColor: '#000000', needsAdmin: true },


### PR DESCRIPTION
Lot of documentation in this PR, but :
- If the exam could be registered but that there is less than 8 business days between the exam date and the desired delivery date, it displays a warning in the modal and in the email, and registers the exam with the status `registered-warning` (in orange on the calendar)
- If the exam could not be registered because of a planning too full or too tight delays, the status is `registered-error` (with a default printing date at the desired delivery date, 07:00 AM), an error is displayed in the modal and in the email, so that the CePro team can do something about the situation.

(also, the `finished` status is now in gray and not in red anymore)

Should fix #113 and #81 