### PR TITLE
Fix/open folder button

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -142,7 +142,7 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                     </div>
                     <div className="date-input flex flex-row flex-wrap gap-4 gap-y-1 [&_input]:rounded-lg flex-1">
                         <label className="font-semibold w-full" htmlFor="contact">Contact</label>
-                        <input className="contact basis-full xl:basis-auto w-full" type="text" name="contact" disabled defaultValue={event?.extendedProps?.contact} />
+                        <input className="contact basis-full xl:basis-auto w-full" type="text" name="contact" disabled defaultValue={`${event?.extendedProps?.contact.firstname} ${event?.extendedProps?.contact.lastname} (${event?.extendedProps?.contact.email})`} />
                     </div>
                 </div>
                 <div className="flex flex-row justify-between gap-x-12 flex-wrap gap-y-0 md:flex-nowrap sm:gap-y-2 items-start">

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -19,14 +19,13 @@ interface AppUser extends User {
 
 interface ModalProps {
     event?: EventApi;
-    shareLink: string;
     user: AppUser;
     examStatus?: { value: string; label: string; color: string, needsAdmin: boolean, fcColor: string }[];
     exams: EventSourceInput | undefined;
     setExams: Dispatch<SetStateAction<EventSourceInput | undefined>>;
 }
 
-export function Modal({ event, shareLink, user, examStatus, exams, setExams }: ModalProps) {
+export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) {
     const [remark, setRemark] = useState(event?.extendedProps?.remark)
     const [reproRemark, setReproRemark] = useState(event?.extendedProps?.reproRemark)
     const [selectStatus, setSelectStatus] = useState(event?.extendedProps?.status)
@@ -172,6 +171,10 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                         <label className="font-semibold w-full" htmlFor="desiredDate">Desired delivery date</label>
                         <input className="exam-date basis-full xl:basis-auto" type="date" name="desiredDate" disabled defaultValue={formatDateOnlyValue(event?.extendedProps?.desiredDate as string | Date | null | undefined)} />
                     </div>
+                    <div className="date-input flex flex-row flex-wrap gap-4 gap-y-1 [&_input]:rounded-lg flex-1">
+                        <label className="font-semibold w-full" htmlFor="folderName">Folder name</label>
+                        <input className="exam-date basis-full xl:basis-auto w-full" type="text" name="folderName" disabled defaultValue={event?.extendedProps?.folderName} />
+                    </div>
                 </div>
             </div>
             <div>
@@ -204,13 +207,6 @@ export function Modal({ event, shareLink, user, examStatus, exams, setExams }: M
                         </select>
                     )}
                     <PrintButton ref={modalRef} />
-                    {/* Open the folder where the exam files are stored */}
-                    <a className="btn btn-secondary group " id="openShare" href={shareLink} target="_blank" rel="noreferrer noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-5">
-                            <path className="opacity-0 group-hover:opacity-100 transition duration-300 ease-out-in" strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />
-                            <path className="opacity-100 group-hover:opacity-0 transition duration-300 ease-in-out" strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
-                        </svg>
-                        Open folder</a>
                 </div>
                 <div className="flex flex-row gap-4">
                     <button className="btn btn-secondary">Cancel</button>

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -186,7 +186,7 @@ export default function Calendar({ user }: CalendarProps) {
           info.event.setExtendedProp('paperFormat', clickedExam?.paperFormat)
           info.event.setExtendedProp('paperColor', clickedExam?.paperColor)
           info.event.setExtendedProp('needScan', clickedExam?.needScan)
-          info.event.setExtendedProp('contact', clickedExam?.contact)
+          info.event.setExtendedProp('contact', JSON.parse(clickedExam?.contact))
           info.event.setExtendedProp('authorizedPersons', JSON.parse(clickedExam?.authorizedPersons)) // Necessary since it's an Array of objects.
           info.event.setExtendedProp('files', JSON.parse(clickedExam?.files)) // Necessary since it's an Array of strings.
           info.event.setExtendedProp('desiredDate', clickedExam?.desiredDate)

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -7,7 +7,7 @@ import interactionPlugin from '@fullcalendar/interaction'; // handles event clic
 import { useEffect, useRef, useState, useMemo, Dispatch } from "react";
 import { EventDropArg, EventInput, EventSourceInput } from "@fullcalendar/core/index.js";
 import { getAllCrepExams, getAllNonAdminExams, updateExamDateById } from "@/app/lib/database";
-import { fromDatabaseDateTime, formatDateTimeForDatabase, formatDateTimeInputValue } from "@/app/lib/dateTime";
+import { fromDatabaseDateTime, formatDateTimeForDatabase, formatDateTimeInputValue, formatDateYYYYMMDD } from "@/app/lib/dateTime";
 import { Modal } from "../Modal";
 import { User } from "next-auth";
 import { getAllowedExamStatus } from "@/app/lib/examStatus";
@@ -38,7 +38,6 @@ function getEndDateOfPrinting(printDate: Date, nbStudents: number): Date {
 export default function Calendar({ user }: CalendarProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<EventApi>();
-  const [shareLink, setShareLink] = useState('#');
 
   const [exams, setExams] = useState<EventSourceInput | undefined>();
   const calRef = useRef<FullCalendar | null>(null);
@@ -84,6 +83,7 @@ export default function Calendar({ user }: CalendarProps) {
           authorizedPersons: e.authorized_persons,
           files: e.files,
           desiredDate: e.desired_date,
+          code: e.exam_code,
         }
       })
       setExams(filteredData);
@@ -176,6 +176,10 @@ export default function Calendar({ user }: CalendarProps) {
         }}
         eventClick={(info) => {
           const clickedExam = Array.isArray(exams) ? exams.find((e: EventInput) => e.id == info.event.id) : undefined;
+          const contact = JSON.parse(clickedExam?.contact);
+
+          const folderName = `${clickedExam?.code}_${contact.lastname}_${formatDateYYYYMMDD(clickedExam?.desiredDate)}`
+
           info.event.setExtendedProp('status', clickedExam?.status);
           info.event.setExtendedProp('remark', clickedExam?.remark);
           info.event.setExtendedProp('reproRemark', clickedExam?.reproRemark)
@@ -190,16 +194,10 @@ export default function Calendar({ user }: CalendarProps) {
           info.event.setExtendedProp('authorizedPersons', JSON.parse(clickedExam?.authorizedPersons)) // Necessary since it's an Array of objects.
           info.event.setExtendedProp('files', JSON.parse(clickedExam?.files)) // Necessary since it's an Array of strings.
           info.event.setExtendedProp('desiredDate', clickedExam?.desiredDate)
+          info.event.setExtendedProp('folderName', folderName)
           setSelectedEvent(info.event);
-          // build the share link once and stash in state
-          const rawPath = "vpsi1files.epfl.ch/CAPE/REPRO/TEST/" + info.event.extendedProps?.folder_name; //folder name doesn't exist yet. snippet from ludo. ToDo
-          const uncURL = `file://///${rawPath}`;
-          const smbURL = `smb://${rawPath}`;
-          const dialog = document.getElementById("modal") as HTMLDialogElement;
-          const isWindows = () =>
-            /windows/i.test(navigator.userAgent);
 
-          setShareLink(isWindows() ? uncURL : smbURL);
+          const dialog = document.getElementById("modal") as HTMLDialogElement;
           dialog.showModal();
           setModalOpen(true);
         }}
@@ -245,7 +243,6 @@ export default function Calendar({ user }: CalendarProps) {
         {modalOpen && (
           <Modal
             event={selectedEvent}
-            shareLink={shareLink}
             user={user}
             exams={exams}
             setExams={setExams}

--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -227,6 +227,12 @@ export default function App({ user }: RegisterProps) {
 
 
             const contact = await fetchPersonBySciper(data.contact);
+            const formattedContact = {
+                id: contact.id,
+                email: contact.email,
+                firstname: contact.firstname,
+                lastname: contact.lastname,
+            }
 
             const exam_name = data.course.value.toString();
             const exam_code = data.course.label.split(' - ')[0] || '';
@@ -374,7 +380,7 @@ export default function App({ user }: RegisterProps) {
                     print_date: printingDate,
                     exam_students: data.nbStudents,
                     exam_pages: data.nbPages,
-                    contact: contact?.firstname + ' ' + contact?.lastname + ' (' + contact?.email + ')',
+                    contact: JSON.stringify(formattedContact),
                     // contact: data.contact, //if we want the id only
                     authorized_persons: JSON.stringify(authorizedPersons),
                     paper_format: data.paperFormat,

--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import ReactSelect from "./ReactSelect";
 import { fetchMultiplePersonsBySciper, fetchPersonBySciper } from "@/app/lib/api";
 import { sendMail } from "@/app/lib/mail";
-import { fromDatabaseDateTime, formatDateTimeForDatabase } from "@/app/lib/dateTime";
+import { fromDatabaseDateTime, formatDateTimeForDatabase, formatDateYYYYMMDD } from "@/app/lib/dateTime";
 import { User } from "next-auth";
 import { RedAsterisk } from "../RedAsterisk";
 import { RegisterModal } from "./RegisterModal";
@@ -155,14 +155,6 @@ export default function App({ user }: RegisterProps) {
             return updated;
         });
     };
-
-    const formatDateYYYYMMDD = (date: Date) => {
-        const yyyy = date.getFullYear();
-        const mm = String(date.getMonth() + 1).padStart(2, "0");
-        const dd = String(date.getDate()).padStart(2, "0");
-
-        return `${yyyy}-${mm}-${dd}`
-    }
 
     const onSubmit: SubmitHandler<Inputs> = async (data) => {
         // validate that desiredDate is not later than examDate

--- a/app/lib/dateTime.ts
+++ b/app/lib/dateTime.ts
@@ -65,3 +65,11 @@ export function getTimePartFromDateTimeString(value: string | null | undefined):
   const match = value.match(/[T ](\d{2}:\d{2})/);
   return match ? match[1] : "";
 }
+
+export function formatDateYYYYMMDD(date: Date) {
+        const yyyy = date.getFullYear();
+        const mm = String(date.getMonth() + 1).padStart(2, "0");
+        const dd = String(date.getDate()).padStart(2, "0");
+
+        return `${yyyy}-${mm}-${dd}`
+    }


### PR DESCRIPTION
- Contact is now a full object in database, as for authorized persons (changes will be made in [CREP.ops](https://github.com/EPFL-CePro/CREP.ops))
- Function `formatDateYYYYMMDD` is now exported in a `lib` file `dateTime.ts` (which already existed with other functions)
- No more `Open Folder` button on the modal, instead we just display the folder name on the modal, which should be `{examCode}_{contactLastname}_{desiredDate}`

This should fix #109 