### PR TITLE
[feature] queryStrings

### DIFF
--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -15,6 +15,7 @@ import { Filters } from "../Filters";
 import { QueryResult } from "mysql2";
 import { Legend } from "../Legend";
 import { EventApi } from "@fullcalendar/core";
+import { useSearchParams } from "next/navigation";
 
 interface CalendarProps {
   user: AppUser
@@ -38,6 +39,10 @@ function getEndDateOfPrinting(printDate: Date, nbStudents: number): Date {
 export default function Calendar({ user }: CalendarProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<EventApi>();
+
+  const searchParams = useSearchParams();
+  const openExamParam = searchParams.get('openExam');
+  const hasOpenedExamFromQueryRef = useRef(false);
 
   const [exams, setExams] = useState<EventSourceInput | undefined>();
   const calRef = useRef<FullCalendar | null>(null);
@@ -108,6 +113,68 @@ export default function Calendar({ user }: CalendarProps) {
     return m;
   }, [availableStatus]);
 
+  function openExamModal(calendarEvent: EventApi, examsList: EventInput[]) {
+    const clickedExam = examsList.find((e: EventInput) => e.id == calendarEvent.id);
+    if (!clickedExam?.contact) return;
+
+    const contact = JSON.parse(clickedExam.contact);
+    const folderName = `${clickedExam.code}_${contact.lastname}_${formatDateYYYYMMDD(clickedExam.desiredDate)}`;
+
+    calendarEvent.setExtendedProp('status', clickedExam.status);
+    calendarEvent.setExtendedProp('remark', clickedExam.remark);
+    calendarEvent.setExtendedProp('reproRemark', clickedExam.reproRemark);
+    calendarEvent.setExtendedProp('financialCenter', clickedExam.financialCenter);
+    calendarEvent.setExtendedProp('examDate', clickedExam.examDate);
+    calendarEvent.setExtendedProp('copiesNumber', clickedExam.copiesNumber);
+    calendarEvent.setExtendedProp('pagesPerCopy', clickedExam.pagesPerCopy);
+    calendarEvent.setExtendedProp('paperFormat', clickedExam.paperFormat);
+    calendarEvent.setExtendedProp('paperColor', clickedExam.paperColor);
+    calendarEvent.setExtendedProp('needScan', clickedExam.needScan);
+    calendarEvent.setExtendedProp('contact', JSON.parse(clickedExam.contact));
+    calendarEvent.setExtendedProp('authorizedPersons', JSON.parse(clickedExam.authorizedPersons)); // Necessary since it's an Array of objects.
+    calendarEvent.setExtendedProp('files', JSON.parse(clickedExam.files)); // Necessary since it's an Array of strings.
+    calendarEvent.setExtendedProp('desiredDate', clickedExam.desiredDate);
+    calendarEvent.setExtendedProp('folderName', folderName);
+    setSelectedEvent(calendarEvent);
+
+    const dialog = document.getElementById("modal") as HTMLDialogElement | null;
+    dialog?.showModal();
+    setModalOpen(true);
+  }
+
+  useEffect(() => {
+    if (!openExamParam || hasOpenedExamFromQueryRef.current || !Array.isArray(exams)) return;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const examToOpen = exams
+      .filter((exam: EventInput) => exam.code == openExamParam && !!exam.start)
+      .map((exam: EventInput) => ({
+        exam,
+        printStartDate: new Date(exam.start as string),
+      }))
+      .filter(({ printStartDate }) => {
+        if (Number.isNaN(printStartDate.getTime())) return false;
+
+        const printDay = new Date(printStartDate);
+        printDay.setHours(0, 0, 0, 0);
+        return printDay >= today;
+      })
+      .sort((a, b) => a.printStartDate.getTime() - b.printStartDate.getTime())[0]?.exam;
+
+    if (!examToOpen) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const calendarEvent = calRef.current?.getApi().getEventById(String(examToOpen.id));
+      if (!calendarEvent) return;
+
+      openExamModal(calendarEvent, exams as EventInput[]);
+      hasOpenedExamFromQueryRef.current = true;
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [exams, openExamParam]);
+
   function makeEventsKey(
     examsArr: EventSourceInput,
     filtersArr: { label: string, value: string }[],
@@ -175,31 +242,8 @@ export default function Calendar({ user }: CalendarProps) {
           listWeek: { buttonText: 'List' },
         }}
         eventClick={(info) => {
-          const clickedExam = Array.isArray(exams) ? exams.find((e: EventInput) => e.id == info.event.id) : undefined;
-          const contact = JSON.parse(clickedExam?.contact);
-
-          const folderName = `${clickedExam?.code}_${contact.lastname}_${formatDateYYYYMMDD(clickedExam?.desiredDate)}`
-
-          info.event.setExtendedProp('status', clickedExam?.status);
-          info.event.setExtendedProp('remark', clickedExam?.remark);
-          info.event.setExtendedProp('reproRemark', clickedExam?.reproRemark)
-          info.event.setExtendedProp('financialCenter', clickedExam?.financialCenter)
-          info.event.setExtendedProp('examDate', clickedExam?.examDate)
-          info.event.setExtendedProp('copiesNumber', clickedExam?.copiesNumber)
-          info.event.setExtendedProp('pagesPerCopy', clickedExam?.pagesPerCopy)
-          info.event.setExtendedProp('paperFormat', clickedExam?.paperFormat)
-          info.event.setExtendedProp('paperColor', clickedExam?.paperColor)
-          info.event.setExtendedProp('needScan', clickedExam?.needScan)
-          info.event.setExtendedProp('contact', JSON.parse(clickedExam?.contact))
-          info.event.setExtendedProp('authorizedPersons', JSON.parse(clickedExam?.authorizedPersons)) // Necessary since it's an Array of objects.
-          info.event.setExtendedProp('files', JSON.parse(clickedExam?.files)) // Necessary since it's an Array of strings.
-          info.event.setExtendedProp('desiredDate', clickedExam?.desiredDate)
-          info.event.setExtendedProp('folderName', folderName)
-          setSelectedEvent(info.event);
-
-          const dialog = document.getElementById("modal") as HTMLDialogElement;
-          dialog.showModal();
-          setModalOpen(true);
+          if (!Array.isArray(exams)) return;
+          openExamModal(info.event, exams as EventInput[]);
         }}
         editable={user.isAdmin ? true : false}
         selectable={true}

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -42,6 +42,7 @@ export default function Calendar({ user }: CalendarProps) {
 
   const searchParams = useSearchParams();
   const openExamParam = searchParams.get('openExam');
+  const dayParam = searchParams.get('day');
   const hasOpenedExamFromQueryRef = useRef(false);
 
   const [exams, setExams] = useState<EventSourceInput | undefined>();
@@ -112,6 +113,33 @@ export default function Calendar({ user }: CalendarProps) {
     (availableStatus || []).forEach(s => m.set(s.value, s.fcColor || "#000000"));
     return m;
   }, [availableStatus]);
+
+  function parseDayParam(value: string): Date | null {
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/); // YYYY-MM-DD
+    if (!match) return null;
+
+    const [, year, month, day] = match;
+    const parsedDate = new Date(Number(year), Number(month) - 1, Number(day));
+
+    if (
+      parsedDate.getFullYear() !== Number(year) ||
+      parsedDate.getMonth() !== Number(month) - 1 ||
+      parsedDate.getDate() !== Number(day)
+    ) {
+      return null;
+    }
+
+    return parsedDate;
+  }
+
+  const targetDayDate = useMemo(() => {
+    if (!dayParam) return undefined;
+
+    const targetDate = parseDayParam(dayParam);
+    if (!targetDate) return undefined;
+
+    return targetDate;
+  }, [dayParam]);
 
   function openExamModal(calendarEvent: EventApi, examsList: EventInput[]) {
     const clickedExam = examsList.find((e: EventInput) => e.id == calendarEvent.id);
@@ -211,9 +239,11 @@ export default function Calendar({ user }: CalendarProps) {
         </div>
       </div>
       <FullCalendar
+        key={targetDayDate ? targetDayDate.toISOString().slice(0, 10) : "current-week"}
         ref={calRef}
         plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
         initialView="timeGridWeek"
+        initialDate={targetDayDate}
         contentHeight="71dvh"
         firstDay={1}
         slotMinTime="07:00:00"


### PR DESCRIPTION
`day` queryString to specify a date and open the calendar directly to the week of the specified date.
`openExam` to specify an exam code, and directly open the exam modal (only if the exam will be printed in the future, it doesn't work for exams that are not planned to be print)

There may be some bugs, use with caution.