### PR TITLE
[refactor] Added `TEST -` prefix before emails from the test environment

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -264,7 +264,7 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                                 const examURL = `https://crep.epfl.ch/?openExam=${event?.extendedProps?.code}&day=${formatDateYYYYMMDD(datePrintSchedule)}`;
                                 await sendMail(
                                     'repro@groupes.epfl.ch',
-                                    `Exam ${event?.extendedProps?.code} is ready to be printed`,
+                                    `${process.env.NODE_ENV == "test" && "TEST -"} Exam ${event?.extendedProps?.code} is ready to be printed`,
                                     `
 Hello,
 
@@ -285,7 +285,7 @@ CePro team
                             if (process.env.NODE_ENV !== "development") {
                                 await sendMail(
                                     event?.extendedProps?.contact.email,
-                                    `Exam ${event?.extendedProps?.code} is ready to be picked up`,
+                                    `${process.env.NODE_ENV == "test" && "TEST -"} Exam ${event?.extendedProps?.code} is ready to be picked up`,
                                     `
 Hello,
 

--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -423,7 +423,7 @@ export default function App({ user }: RegisterProps) {
             if (process.env.NODE_ENV !== "development") {
                 await sendMail(
                     user.email || '',
-                    `${status == 'registered-warning' || status == 'registered-error' ? 'REQUIRES ATTENTION - ' : ''} CePro - Exam printing service subscription confirmation`,
+                    `${process.env.NODE_ENV == "test" && "TEST -"} ${status == 'registered-warning' || status == 'registered-error' ? 'REQUIRES ATTENTION - ' : ''} CePro - Exam printing service subscription confirmation`,
                     `
 Hello,
 Your subscription to our exam printing service has been registered:


### PR DESCRIPTION
Since the distinction is already done in [CREP.ops](https://github.com/EPFL-CePro/CREP.ops), this should be the only changes that have to be made. But some things can still come later.

Fix #142 