### PR TITLE
[refactor] Only get "blocking" exams for the algorithm

### DIFF
--- a/app/components/forms/register.tsx
+++ b/app/components/forms/register.tsx
@@ -1,7 +1,7 @@
 "use client";
 // This form allows users to register their exams into the system.
 import { useForm, SubmitHandler } from "react-hook-form"
-import { getAllExamsBetweenDates, getAllExamsForDate, insertExamForPrint } from "@/app/lib/database";
+import { getAllExamsBetweenDates, getBlockingExamsForDate, insertExamForPrint } from "@/app/lib/database";
 import { useState } from "react";
 import ReactSelect from "./ReactSelect";
 import { fetchMultiplePersonsBySciper, fetchPersonBySciper } from "@/app/lib/api";
@@ -306,7 +306,7 @@ export default function App({ user }: RegisterProps) {
                     const month = String(date.getMonth() + 1).padStart(2, '0');
                     const day = String(date.getDate()).padStart(2, '0');
 
-                    const allExamsForDate = await getAllExamsForDate(`${year}-${month}-${day}`);
+                    const allExamsForDate = await getBlockingExamsForDate(`${year}-${month}-${day}`);
 
                     if (allExamsForDate.length == 0) {
                         date.setHours(8, 0, 0, 0);

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -1,7 +1,7 @@
 'use server';
 import mysql from 'mysql2';
 import type { ResultSetHeader } from 'mysql2';
-import { examNotAdminStatus } from './examStatus';
+import { examBlockingPrintStatus, examNotAdminStatus } from './examStatus';
 import { Service } from '@/types/service';
 import { ExamType } from '@/types/examType';
 import { AcademicYear, FormattedAcademicYear } from '@/types/academicYear';
@@ -240,6 +240,29 @@ export async function getAllExamsForDate(date:string): Promise <CrepExam[]> {
             if (err) throw err
             resolve(rows as CrepExam[]);
         })
+        connection.end()
+    })
+}
+
+export async function getBlockingExamsForDate(date:string): Promise <CrepExam[]> {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    return new Promise(function(resolve) {
+        connection.query(
+            'SELECT * FROM crep WHERE DATE(print_date) = DATE(?) AND status IN (?);',
+            [date, examBlockingPrintStatus],
+            (err, rows) => {
+                if (err) throw err
+                resolve(rows as CrepExam[]);
+            }
+        )
         connection.end()
     })
 }

--- a/app/lib/examStatus.ts
+++ b/app/lib/examStatus.ts
@@ -27,6 +27,14 @@ export const examNotAdminStatus = examStatus.filter(status => !status.needsAdmin
 
 export const examAdminStatus = examStatus.filter(status => status.needsAdmin);
 
+export const examBlockingPrintStatus = [
+    'registered',
+    'registered-warning',
+    'registered-error',
+    'toPrint',
+    'printing',
+];
+
 export const getAllowedExamStatus = (isAdmin: boolean) => {
     return isAdmin ? examStatus : examNotAdminStatus;
 }


### PR DESCRIPTION
Algorithm was using all the exams in the database for the specified date.

The new `getBlockingExamsForDate` function only get the exams that have one of the status specified in the const `examBlockingPrintStatus` in `examStatus.ts`.

Meaning that if an exam is `finished` and that another exam can be printed there, the slot will be taken.

Fix #80
Fix #135 

Warning : This has not been tested enough, everything is subject to change.