### PR TITLE
[refactor] Moving tasks restrictions

### DIFF
--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -109,6 +109,18 @@ export default function Calendar({ user }: CalendarProps) {
     const formattedStartDate = arg.event.startStr
       ? arg.event.startStr.slice(0, 19).replace("T", " ")
       : formatDateTimeForDatabase(startDate || new Date());
+    const formattedEventStart = arg.event.startStr
+      ? arg.event.startStr.slice(0, 19)
+      : startDate ? formatDateTimeInputValue(startDate) : undefined;
+    const formattedEventEnd = arg.event.endStr
+      ? arg.event.endStr.slice(0, 19)
+      : arg.event.end ? formatDateTimeInputValue(arg.event.end) : undefined;
+    const previousEventStart = arg.oldEvent.startStr
+      ? arg.oldEvent.startStr.slice(0, 19)
+      : arg.oldEvent.start ? formatDateTimeInputValue(arg.oldEvent.start) : undefined;
+    const previousEventEnd = arg.oldEvent.endStr
+      ? arg.oldEvent.endStr.slice(0, 19)
+      : arg.oldEvent.end ? formatDateTimeInputValue(arg.oldEvent.end) : undefined;
 
     const newStart = arg.event.start;
     const examDateRaw = arg.event.extendedProps.examDate;
@@ -126,7 +138,40 @@ export default function Calendar({ user }: CalendarProps) {
       return;
     }
 
-    await updateExamDateById(id, formattedStartDate)
+    if (!formattedEventStart) {
+      arg.revert();
+      return;
+    }
+
+    setExams((currentExams: EventSourceInput | undefined) => Array.isArray(currentExams)
+      ? currentExams.map((exam: EventInput) => exam.id == id
+        ? {
+          ...exam,
+          start: formattedEventStart,
+          end: formattedEventEnd,
+        }
+        : exam)
+      : currentExams
+    );
+    eventsCacheRef.current = { key: "", events: [] };
+
+    try {
+      await updateExamDateById(id, formattedStartDate)
+    } catch (error) {
+      setExams((currentExams: EventSourceInput | undefined) => Array.isArray(currentExams)
+        ? currentExams.map((exam: EventInput) => exam.id == id
+          ? {
+            ...exam,
+            start: previousEventStart,
+            end: previousEventEnd,
+          }
+          : exam)
+        : currentExams
+      );
+      eventsCacheRef.current = { key: "", events: [] };
+      arg.revert();
+      console.error("Failed to update exam print date", error);
+    }
   }
 
   const eventsCacheRef = useRef<{ key: string; events: EventInput[] }>({ key: "", events: [] });
@@ -239,7 +284,7 @@ export default function Calendar({ user }: CalendarProps) {
       fcColor: string;
       needsAdmin: boolean;
     }[]) {
-    const examsPart = Array.isArray(examsArr) ? examsArr.map(e => `${e.id}:${e.status}`).join("|") : "";
+    const examsPart = Array.isArray(examsArr) ? examsArr.map(e => `${e.id}:${e.status}:${e.start}:${e.end}`).join("|") : "";
     const filtersPart = (filtersArr || []).map(f => f.value).join(",");
     const statusPart = (examStatusArr || []).map(s => `${s.value}:${s.fcColor}`).join(",");
 

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -303,6 +303,7 @@ export default function Calendar({ user }: CalendarProps) {
             const today = new Date();
             const isToday = eventStartPrintDate.setHours(0, 0, 0, 0) === today.setHours(0, 0, 0, 0);
             const isBreathingPrint = isToday && ev.status === "toPrint";
+            const isMovable = ["registered", "registered-warning", "registered-error", "toPrint"].includes(ev.status);
 
             return {
               ...ev,
@@ -312,6 +313,7 @@ export default function Calendar({ user }: CalendarProps) {
                 isBreathingPrint ? "fc-event-breathing-pink" : ""
               ].filter(Boolean),
               extendedProps: { ...(ev.extendedProps || {}), status: ev.status, remark: ev.remark, reproRemark: ev.reproRemark },
+              startEditable: isMovable,
             };
           });
 

--- a/app/components/calendar/FullCalendar.tsx
+++ b/app/components/calendar/FullCalendar.tsx
@@ -97,12 +97,34 @@ export default function Calendar({ user }: CalendarProps) {
     })();
   }, [availableStatus, user.isAdmin])
 
+  const startOfDay = (date: Date) => {
+    const copy = new Date(date);
+    copy.setHours(0, 0, 0, 0);
+    return copy;
+  };
+
   const handleEventDrop = async (arg: EventDropArg) => {
     const id = arg.event.id;
     const startDate = arg.event.start;
     const formattedStartDate = arg.event.startStr
       ? arg.event.startStr.slice(0, 19).replace("T", " ")
       : formatDateTimeForDatabase(startDate || new Date());
+
+    const newStart = arg.event.start;
+    const examDateRaw = arg.event.extendedProps.examDate;
+
+    if (!newStart || !examDateRaw) {
+      arg.revert();
+      return;
+    }
+
+    const movedDate = startOfDay(newStart);
+    const examDate = startOfDay(new Date(examDateRaw));
+
+    if (movedDate > examDate) {
+      arg.revert();
+      return;
+    }
 
     await updateExamDateById(id, formattedStartDate)
   }
@@ -312,7 +334,7 @@ export default function Calendar({ user }: CalendarProps) {
               classNames: [
                 isBreathingPrint ? "fc-event-breathing-pink" : ""
               ].filter(Boolean),
-              extendedProps: { ...(ev.extendedProps || {}), status: ev.status, remark: ev.remark, reproRemark: ev.reproRemark },
+              extendedProps: { ...(ev.extendedProps || {}), status: ev.status, remark: ev.remark, reproRemark: ev.reproRemark, examDate: ev.examDate },
               startEditable: isMovable,
             };
           });


### PR DESCRIPTION
- You can only move an exam if status is `registered`, `registered-warning`, `registered-error` or `toPrint`
- You can't move an exam to a date that is after the exam date
- The bug of moving an exam and then paginating without refreshing the page is now fixed.

Fix #45 
Fix #115 