### PR TITLE
[fix] Redirecting to correct URL after login

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,6 +1,14 @@
 import { signIn } from "@/auth"
 
+function getSafeCallbackUrl(callbackUrl: string | null) {
+	if (!callbackUrl || !callbackUrl.startsWith('/') || callbackUrl.startsWith('//')) {
+		return '/';
+	}
+
+	return callbackUrl;
+}
+
 export async function GET(req: Request) {
 	const searchParams = new URL(req.url).searchParams;
-	return signIn('microsoft-entra-id', { redirectTo: searchParams.get('callbackUrl') ?? '/' });
+	return signIn('microsoft-entra-id', { redirectTo: getSafeCallbackUrl(searchParams.get('callbackUrl')) });
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ export default async function middleware(req: NextRequest) {
 
 	if (!session?.user) {
 		const authUrl = new URL('/api/auth', req.url);
-		authUrl.searchParams.set('callbackUrl', req.url);
+		authUrl.searchParams.set('callbackUrl', `${req.nextUrl.pathname}${req.nextUrl.search}`);
 		return NextResponse.redirect(authUrl);
 	}
 


### PR DESCRIPTION
After logging in, if you tried to access to `/register` you should be redirected to `/register`

May not work in production, changes are still possible.

close #85 