### PR TITLE
[fix] Oasis `/enseignant-cours/modules` instead of `/enseignant-cours`

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -67,7 +67,7 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
     } else {
         currentYear = date.getFullYear().toString() + '-' + (date.getFullYear() +1).toString();
     }
-    const url = `${getOasisBaseUrl()}/enseignant-cours/${currentYear}`;
+    const url = `${getOasisBaseUrl()}/enseignant-cours/modules/${currentYear}`;
     const headers = new Headers();
     headers.set('Access-Control-Allow-Origin', '*');
     headers.set('Access-Control-Allow-Headers', '*');


### PR DESCRIPTION
With the new changes on Oasis, we should now use this...