### PR TITLE
[refactor] Setting status to `finished` while `boxes`, `price unit` or `price total` are still set to 0

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -452,11 +452,10 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                         }
 
                         if (shouldNotifyFinished) {
-                            if(parseInt(boxes) <= 0) {
-                                if (!window.confirm("You are changing the status to `finished`, but the number of boxes for this exam is still set to 0. Are you sure you want to proceed?")) {
-                                    setSelectStatus(previousStatus);
-                                    return;
-                                }
+                            if(parseInt(boxes) <= 0 || parseInt(priceUnit) <= 0 || parseInt(priceTotal) <= 0) {
+                                window.alert("To change the status to `Finished`, these fields need to be set to something bigger than 0 : Number of boxes, Price Unit, Price Total");
+                                setSelectStatus(previousStatus);
+                                return;
                             }
                             // proceed only if confirmed, else prevent modal close and save
                             if (!window.confirm("You are changing the status to `finished`. This will send an email to the contact person and authorized persons saying that they can pick up the exam at the Repro. Are you sure you want to proceed?")) {


### PR DESCRIPTION
If one of those fields are still set to "0", there is now a whole error and not just a confirm dialog. Meaning that it is necessary to set them to something greater than 0.