### PR TITLE
Feature/group courses by teachers

### DIFF
--- a/app/components/crep/register.tsx
+++ b/app/components/crep/register.tsx
@@ -245,8 +245,8 @@ export default function App({ user }: RegisterProps) {
                 lastname: contact.lastname,
             }
 
-            const exam_name = data.course.value.toString();
-            const exam_code = data.course.label.split(' - ')[0] || '';
+            const exam_name = `${data.course.exam.title} (${data.course.exam.teachers.map((t) => `${t.firstname} ${t.name}`).join(', ')})`;
+            const exam_code = data.course.exam.code;
             const contact_name = contact?.lastname;
 
             function getEndDateOfPrinting(exam: Exam): Date {

--- a/app/components/exams/ExamsTable.tsx
+++ b/app/components/exams/ExamsTable.tsx
@@ -21,9 +21,10 @@ import { Service } from '@/types/service'
 import { ExamType } from '@/types/examType'
 import { ExamStatus } from '@/types/examStatus'
 import { FormattedSection } from '@/types/section'
-import { fetchCeproAdminsIT, fetchPersonBySciper } from '@/app/lib/api'
+import { fetchCeproAdminsIT, fetchPersonBySciper, fetchTeachersByCourseCode } from '@/app/lib/api'
 import { EPFLUser } from '@/types/user'
 import { GroupUser } from '@/types/groupUser'
+import { Teacher } from '@/types/teacher'
 
 interface ExamsTableProps {
   academicYear: string
@@ -50,6 +51,7 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
   const [isLoadingContact, setIsLoadingContact] = React.useState(false)
   const [isLoadingTable, setIsLoadingTable] = React.useState(true)
   const [allCeproAdminsIT, setAllCeproAdminsIT] = React.useState<GroupUser[]>([])
+  const [teachersByCourse, setTeachersByCourse] = React.useState<Record<string, Teacher[]>>({})
   const latestContactRequest = React.useRef<string | null>(null)
   const compactSelectClassName =
     'h-9 max-w-[9rem] rounded-xl border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-600'
@@ -85,6 +87,7 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
           sections,
           allAcademicYears,
           ceproAdminsIT,
+          teachers,
         ] = await Promise.all([
           getExamsByAcademicYear(academicYear) as Promise<Exam[]>,
           getAllServiceLevels(),
@@ -94,6 +97,11 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
           getAllSections(),
           getAllAcademicYears() as Promise<FormattedAcademicYear[]>,
           fetchCeproAdminsIT() as Promise<GroupUser[]>,
+          // The table can still render even if Oasis is down
+          fetchTeachersByCourseCode(academicYear).catch((error) => {
+            console.error('Failed to fetch teachers from Oasis', error)
+            return {} as Record<string, Teacher[]>
+          }),
         ])
 
         if (!isActive) return
@@ -106,6 +114,7 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
         setAllSections(sections)
         setAcademicYears(allAcademicYears.reverse()) // Reversing so that the most recent academic year is at the top of the select
         setAllCeproAdminsIT(ceproAdminsIT)
+        setTeachersByCourse(teachers)
       } finally {
         if (isActive) {
           setIsLoadingTable(false)
@@ -191,6 +200,30 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
           </div>
         </div>
       ),
+    },
+    {
+      id: 'teachers',
+      header: 'Teachers',
+      // Joined string so that the default text filtering and sorting apply
+      accessorFn: (row) =>
+        (teachersByCourse[row.code] ?? [])
+          .map((t) => `${t.firstname} ${t.name}`)
+          .join(`,`),
+      cell: ({ row }) => {
+        const teachers = teachersByCourse[row.original.code] ?? []
+        if (!teachers.length) {
+          return <div className="min-w-0 max-w-[14rem] text-sm text-slate-700">—</div>
+        }
+        return (
+          <div className="min-w-0 max-w-[14rem] text-sm text-slate-700">
+            {teachers.map((t) => (
+              <div key={`${t.sciper ?? `${t.firstname} ${t.name}`}`}>
+                {t.firstname} {t.name}
+              </div>
+            ))}
+          </div>
+        )
+      },
     },
     {
       accessorKey: 'service_level_id',
@@ -712,9 +745,15 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
 
       const remark = row.original.remark?.toLowerCase() ?? ''
 
+      const teachersDisplay = (teachersByCourse[row.original.code] ?? [])
+        .map((t) => `${t.firstname} ${t.name}`)
+        .join(', ')
+        .toLowerCase()
+
       return (
         row.original.name.toLowerCase().includes(search) ||
         row.original.code.toLowerCase().includes(search) ||
+        teachersDisplay.includes(search) ||
         (allServiceLevels.find((element:ServiceLevel) => element.id == row.original.service_level_id)?.name.toLowerCase().includes(search) || false) ||
         (allServices.find((element:Service) => element.id == row.original.service_id)?.code.toLowerCase().includes(search) || false) ||
         (allExamTypes.find((element:ExamType) => element.id == row.original.exam_type_id)?.code.toLowerCase().includes(search) || false) ||

--- a/app/components/forms/teachersExamForm.tsx
+++ b/app/components/forms/teachersExamForm.tsx
@@ -176,7 +176,7 @@ Hello,
 Your subscription to our exam services has been successfully registered:
 
 - Course: ${data.course.exam.code}
-- Teacher: ${data.course.exam.teacherFirstname} ${data.course.exam.teacherName} (${data.course.exam.teacherSciper})
+- Teacher${data.course.exam.teachers.length > 1 ? 's' : ''}: ${data.course.exam.teachers.map((t) => `${t.firstname} ${t.name}${t.sciper ? ` (${t.sciper})` : ''}`).join(', ')}
 - Contact: ${contact.email}
 - Type${data.examType.filter((examType) => examType.checked).length > 1 ? 's' : ''} of exam: ${data.examType.filter((examType) => examType.checked).map((examType) => examType.name).join(', ')}
 - Service: ${service[0].description}
@@ -292,7 +292,7 @@ CePro
                 encType="multipart/form-data">
                 {/* register your input into the hook by invoking the "register" function */}
                 <label>Your email address</label>
-                <ReactSelect control={control} label={"registeredBy"} name={"registeredBy"} isMultiChoice={false} instanceId={2} user={user} disabled={true}/>
+                <ReactSelect control={control} label={"registeredBy"} name={"contact"} isMultiChoice={false} instanceId={2} user={user} disabled={true}/>
                 <label>Academic Year <RedAsterisk /></label>
                 <Controller
                     name="academicYear"

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2,6 +2,7 @@
 import { EPFLUser } from "@/types/user";
 import { SelectOption } from "../components/forms/ReactSelect";
 import { GroupUser } from "@/types/groupUser";
+import { Teacher } from "@/types/teacher";
 
 function getOasisBaseUrl(): string {
     if (process.env.OASIS_BASE_URL) {
@@ -101,6 +102,49 @@ export async function fetchMultiplePersonsBySciper(scipersWithCommas: string): P
     return data.persons;
 }
 
+interface OasisTeacherCourse {
+    coursNomFr: string;
+    coursCode?: string;
+    enseignantPrenom: string;
+    enseignantNom: string;
+    enseignantSciper?: string;
+    enseignantRole?: string;
+    coursSeanceCode?: string;
+}
+
+// Oasis returns one row per teacher-course relation.
+async function fetchOasisTeacherCourses(academicYear: string): Promise<OasisTeacherCourse[]> {
+    const url = `${getOasisBaseUrl()}/enseignant-cours/${academicYear}?type=Enseignement`;
+    const headers = new Headers();
+    headers.set('Access-Control-Allow-Origin', '*');
+    headers.set('Access-Control-Allow-Headers', '*');
+
+    const bearerToken = process.env.OASIS_BEARER;
+    if (bearerToken) {
+        headers.set('Authorization', `Bearer ${bearerToken}`);
+    }
+
+    const res = await fetch(url, {method: 'GET', headers});
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data as OasisTeacherCourse[];
+}
+
+function addTeacherOnce(teachers: Teacher[], row: OasisTeacherCourse) {
+    const alreadyListed = teachers.some(t =>
+        row.enseignantSciper
+            ? t.sciper === row.enseignantSciper
+            : t.firstname === row.enseignantPrenom && t.name === row.enseignantNom
+    );
+    if (!alreadyListed) {
+        teachers.push({
+            firstname: row.enseignantPrenom,
+            name: row.enseignantNom,
+            sciper: row.enseignantSciper,
+        });
+    }
+}
+
 export async function fetchCourses(academicYear?: string): Promise<SelectOption[]> {
     const date = new Date();
     const month = date.getMonth();
@@ -112,38 +156,15 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
     } else {
         currentYear = date.getFullYear().toString() + '-' + (date.getFullYear() +1).toString();
     }
-    const url = `${getOasisBaseUrl()}/enseignant-cours/${currentYear}?type=Enseignement`;
-    const headers = new Headers();
-    headers.set('Access-Control-Allow-Origin', '*');
-    headers.set('Access-Control-Allow-Headers', '*');
-
-    const bearerToken = process.env.OASIS_BEARER;
-    if (bearerToken) {
-        headers.set('Authorization', `Bearer ${bearerToken}`);
-    }
-
-    const res = await fetch(url, {method: 'GET', headers});
-    const data = await res.json();
-
-    interface OasisCourse {
-        coursNomFr: string;
-        coursCode: string;
-        enseignantPrenom: string;
-        enseignantNom: string;
-        enseignantSciper?: string;
-        enseignantRole?: string;
-        coursSeanceCode: string;
-    }
-    const courses = data as OasisCourse[];
+    const courses = await fetchOasisTeacherCourses(currentYear);
 
     // const filteredCourses = courses.filter(cours => cours.coursSeanceCode == 'LIP_COURS');
 
-    // The API returns one row per teacher-course relation: group rows by course so
-    // that a course taught by several teachers only appears once in the select.
+    // Group rows by course so that a course taught by several teachers only appears once in the select.
     interface GroupedCourse {
         code: string;
         title: string;
-        teachers: { firstname: string; name: string; sciper?: string }[];
+        teachers: Teacher[];
     }
     const grouped = new Map<string, GroupedCourse>();
     for (const c of courses) {
@@ -159,18 +180,7 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
             };
             grouped.set(key, course);
         }
-        const alreadyListed = course.teachers.some(t =>
-            c.enseignantSciper
-                ? t.sciper === c.enseignantSciper
-                : t.firstname === c.enseignantPrenom && t.name === c.enseignantNom
-        );
-        if (!alreadyListed) {
-            course.teachers.push({
-                firstname: c.enseignantPrenom,
-                name: c.enseignantNom,
-                sciper: c.enseignantSciper,
-            });
-        }
+        addTeacherOnce(course.teachers, c);
     }
 
     return Array.from(grouped.entries()).map(([key, course]) => ({
@@ -182,6 +192,22 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
           teachers: course.teachers,
       }
     }))
+}
+
+// Fetch all courses, group teachers for each course
+export async function fetchTeachersByCourseCode(academicYear: string): Promise<Record<string, Teacher[]>> {
+    const rows = await fetchOasisTeacherCourses(academicYear);
+
+    const teachersByCourse: Record<string, Teacher[]> = {};
+    for (const row of rows) {
+        if (!row.coursCode) continue;
+        if (row.enseignantRole && row.enseignantRole !== 'Enseignement') continue;
+
+        const teachers = teachersByCourse[row.coursCode] ?? (teachersByCourse[row.coursCode] = []);
+        addTeacherOnce(teachers, row);
+    }
+
+    return teachersByCourse;
 }
 
 export async function fetchCeproAdminsIT(): Promise<GroupUser[]> {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -112,7 +112,7 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
     } else {
         currentYear = date.getFullYear().toString() + '-' + (date.getFullYear() +1).toString();
     }
-    const url = `${getOasisBaseUrl()}/enseignant-cours/${currentYear}`;
+    const url = `${getOasisBaseUrl()}/enseignant-cours/${currentYear}?type=Enseignement`;
     const headers = new Headers();
     headers.set('Access-Control-Allow-Origin', '*');
     headers.set('Access-Control-Allow-Headers', '*');
@@ -131,21 +131,55 @@ export async function fetchCourses(academicYear?: string): Promise<SelectOption[
         enseignantPrenom: string;
         enseignantNom: string;
         enseignantSciper?: string;
+        enseignantRole?: string;
         coursSeanceCode: string;
     }
     const courses = data as OasisCourse[];
 
     // const filteredCourses = courses.filter(cours => cours.coursSeanceCode == 'LIP_COURS');
 
-    return courses.map(c => ({
-      value: `${c.coursNomFr} (${c.enseignantPrenom} ${c.enseignantNom})`,
-      label: `${c.coursCode ? c.coursCode : 'Unspecified Code'} - ${c.coursNomFr} (${c.enseignantPrenom} ${c.enseignantNom})`,
+    // The API returns one row per teacher-course relation: group rows by course so
+    // that a course taught by several teachers only appears once in the select.
+    interface GroupedCourse {
+        code: string;
+        title: string;
+        teachers: { firstname: string; name: string; sciper?: string }[];
+    }
+    const grouped = new Map<string, GroupedCourse>();
+    for (const c of courses) {
+        if (c.enseignantRole && c.enseignantRole !== 'Enseignement') continue;
+
+        const key = `${c.coursCode ?? ''}|${c.coursNomFr}`;
+        let course = grouped.get(key);
+        if (!course) {
+            course = {
+                code: c.coursCode ? c.coursCode : 'Unspecified Code',
+                title: c.coursNomFr,
+                teachers: [],
+            };
+            grouped.set(key, course);
+        }
+        const alreadyListed = course.teachers.some(t =>
+            c.enseignantSciper
+                ? t.sciper === c.enseignantSciper
+                : t.firstname === c.enseignantPrenom && t.name === c.enseignantNom
+        );
+        if (!alreadyListed) {
+            course.teachers.push({
+                firstname: c.enseignantPrenom,
+                name: c.enseignantNom,
+                sciper: c.enseignantSciper,
+            });
+        }
+    }
+
+    return Array.from(grouped.entries()).map(([key, course]) => ({
+      value: key,
+      label: `${course.code} - ${course.title} (${course.teachers.map(t => `${t.firstname} ${t.name}`).join(', ')})`,
       exam: {
-          code: c.coursCode ? c.coursCode : 'Unspecified Code',
-          title: c.coursNomFr,
-          teacherName: c.enseignantNom,
-          teacherFirstname: c.enseignantPrenom,
-          teacherSciper: c.enseignantSciper,
+          code: course.code,
+          title: course.title,
+          teachers: course.teachers,
       }
     }))
 }

--- a/types/inputs.ts
+++ b/types/inputs.ts
@@ -5,13 +5,11 @@ import { FormattedSection } from "./section";
 type SelectOption = { 
     value: string | number;
     label: string;
-    exam: { 
+    exam: {
         code: string;
-        teacherFirstname: string;
-        teacherName: string;
-        teacherSciper: string;
         title: string;
-    } 
+        teachers: { firstname: string; name: string; sciper?: string }[];
+    }
 };
 
 export type Inputs = {

--- a/types/teacher.ts
+++ b/types/teacher.ts
@@ -1,0 +1,5 @@
+export type Teacher = {
+    firstname: string;
+    name: string;
+    sciper?: string;
+};


### PR DESCRIPTION
Courses are now grouped by teachers.

If multiple teachers for one course, it's now displayed as `MATH-101(f) (Prof1, Prof2, Prof3, ...)`.
The data scheme of Oasis is still a bit messy, so it is subject to make some strange things. Will refactor if I see too many problems.

Also added a `Teachers` column on the `/exams` route.