### PR TITLE
[feature] Searching an exam with input on CREP calendar

### DIFF
--- a/app/components/crep/calendar/ExamSearch.tsx
+++ b/app/components/crep/calendar/ExamSearch.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { EventInput } from "@fullcalendar/core/index.js";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { fromDatabaseDateTime } from "@/app/lib/dateTime";
+
+type ExamSearchProps = {
+  exams: EventInput[];
+  onSelect: (exam: EventInput) => void;
+};
+
+type Contact = {
+  firstname?: string;
+  lastname?: string;
+};
+
+type SearchableExam = {
+  exam: EventInput;
+  label: string;
+  printDate: string;
+  searchText: string;
+};
+
+const MAX_RESULTS = 8;
+
+function parseContact(value: unknown): Contact {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value) as Contact;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? "").toLowerCase();
+}
+
+function formatPrintDate(start: unknown): string {
+  if (!start) return "";
+  const date = fromDatabaseDateTime(new Date(start as string));
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString("fr-CH", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function ExamSearch({ exams, onSelect }: ExamSearchProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const deferredQuery = useDeferredValue(query);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const searchableExams = useMemo<SearchableExam[]>(
+    () =>
+      exams.map((exam) => {
+        const contact = parseContact(exam.contact);
+        const searchText = [
+          exam.code,
+          exam.description,
+          contact.firstname,
+          contact.lastname,
+        ]
+          .map(normalize)
+          .join(" ");
+
+        return {
+          exam,
+          label: `${exam.code} - ${exam.description ?? ""}`,
+          printDate: formatPrintDate(exam.start),
+          searchText,
+        };
+      }),
+    [exams]
+  );
+
+  const results = useMemo(() => {
+    const search = deferredQuery.trim().toLowerCase();
+    if (!search) return [];
+
+    return searchableExams
+      .filter(({ searchText }) => searchText.includes(search))
+      .slice(0, MAX_RESULTS);
+  }, [deferredQuery, searchableExams]);
+
+  // Close the dropdown when clicking outside.
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function handleSelect(exam: EventInput) {
+    onSelect(exam);
+    setOpen(false);
+    setQuery("");
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <label className="block">
+        <span className="sr-only">Search an exam</span>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder="Search an exam..."
+          className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none transition placeholder:text-slate-400 focus:border-red-300 focus:ring-4 focus:ring-red-100"
+        />
+      </label>
+
+      {open && deferredQuery.trim() !== "" && (
+        <ul className="absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white py-1 shadow-lg">
+          {results.length === 0 ? (
+            <li className="px-3 py-2 text-sm text-slate-500">
+              No exam matches your search.
+            </li>
+          ) : (
+            results.map(({ exam, label, printDate }) => (
+              <li key={exam.id}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(exam)}
+                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm hover:bg-slate-50"
+                >
+                  <span className="font-medium text-slate-800">{label}</span>
+                  {printDate && (
+                    <span className="text-xs text-slate-500">{printDate}</span>
+                  )}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/components/crep/calendar/FullCalendar.tsx
+++ b/app/components/crep/calendar/FullCalendar.tsx
@@ -12,6 +12,7 @@ import { Modal } from "../../Modal";
 import { User } from "next-auth";
 import { getAllowedExamStatus } from "@/app/lib/examStatus";
 import { Filters } from "../../Filters";
+import { ExamSearch } from "./ExamSearch";
 import { QueryResult } from "mysql2";
 import { Legend } from "../../Legend";
 import { EventApi } from "@fullcalendar/core";
@@ -243,6 +244,23 @@ export default function Calendar({ user }: CalendarProps) {
     setModalOpen(true);
   }
 
+  function handleSearchSelect(exam: EventInput) {
+    const api = calRef.current?.getApi();
+    if (!api || !exam.start) return;
+
+    const printDate = new Date(exam.start as string);
+    if (Number.isNaN(printDate.getTime())) return;
+
+    // Jump the calendar to the week of the selected exam, then open its modal.
+    api.gotoDate(printDate);
+
+    window.requestAnimationFrame(() => {
+      const calendarEvent = api.getEventById(String(exam.id));
+      if (!calendarEvent || !Array.isArray(exams)) return;
+      openExamModal(calendarEvent, exams as EventInput[]);
+    });
+  }
+
   useEffect(() => {
     if (!openExamParam || hasOpenedExamFromQueryRef.current || !Array.isArray(exams)) return;
 
@@ -303,12 +321,20 @@ export default function Calendar({ user }: CalendarProps) {
             <Legend />
           </div>
         </div>
-        <div className=" flex-min-2 md:min-w-80 w-full md:w-auto">
-          <Filters
-            examStatus={availableStatus}
-            user={user}
-            setFilters={setFilters as Dispatch<unknown>}
-          />
+        <div className="flex flex-col gap-2 w-full md:w-auto md:flex-row md:items-start">
+          <div className="flex-min-2 md:min-w-64 w-full md:w-auto">
+            <ExamSearch
+              exams={Array.isArray(exams) ? (exams as EventInput[]) : []}
+              onSelect={handleSearchSelect}
+            />
+          </div>
+          <div className="flex-min-2 md:min-w-80 w-full md:w-auto">
+            <Filters
+              examStatus={availableStatus}
+              user={user}
+              setFilters={setFilters as Dispatch<unknown>}
+            />
+          </div>
         </div>
       </div>
       <FullCalendar

--- a/app/components/exams/ExamsTable.tsx
+++ b/app/components/exams/ExamsTable.tsx
@@ -603,15 +603,18 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
       cell: ({ row }) => (
         <div>
           <select
-              defaultValue={allCeproAdminsIT.find((element:GroupUser) => Number(element.id) == Number(row.original.responsible_id))?.id}
+              defaultValue={row.original.responsible_id?.toString() ?? 'None'}
               className="h-9 max-w-[11rem] rounded-xl border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-600"
               onChange={async (e) => {
-                await updateExamResponsible(row.original.id, e.target.value)
+                const responsibleId = e.target.value ? Number(e.target.value) : null
+
+                await updateExamResponsible(row.original.id, responsibleId)
                 updateExamInState(row.original.id, {
-                  responsible_id: e.target.value ? Number(e.target.value) : null,
+                  responsible_id: responsibleId,
                 })
               }}
             >
+              <option value="None">None</option>
               {allCeproAdminsIT.map((adminIT) => (
                 <option key={adminIT.id} value={adminIT.id}>
                   {adminIT.display}
@@ -631,7 +634,7 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
             )
             ?.display.toLowerCase() ?? ''
 
-        return adminITDisplay.includes(search)
+        return adminITDisplay.includes(search) || (!adminITDisplay && 'none'.includes(search))
       },
       sortingFn: (firstRow, secondRow, columnId) => {
         const adminITDisplayA =
@@ -742,6 +745,7 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
             (element: GroupUser) => Number(element.id) == Number(row.original.responsible_id)
           )
           ?.display.toLowerCase() ?? ''
+      const hasNoResponsible = row.original.responsible_id == null
 
       const remark = row.original.remark?.toLowerCase() ?? ''
 
@@ -764,7 +768,8 @@ export default function ExamsTable({ academicYear }: ExamsTableProps) {
         !isNaN(Number(search)) && row.original.nb_pages == Number(search) ||
         remark.includes(search) ||
         (allSections.find((element:FormattedSection) => element.section.id == row.original.section_id)?.section.code.toLowerCase().includes(search) || false) ||
-        responsibleDisplay.includes(search)
+        responsibleDisplay.includes(search) ||
+        (hasNoResponsible && 'none'.includes(search))
       )
     },
     getCoreRowModel: getCoreRowModel(),

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -393,7 +393,7 @@ export async function updateExamRemark(examId: string, remark: string) {
     })
 }
 
-export async function updateExamResponsible(examId: string, responsibleId: string) {
+export async function updateExamResponsible(examId: string, responsibleId: number | null) {
     const connection = mysql.createConnection({
         host: process.env.MYSQL_HOST,
         user: process.env.MYSQL_USER,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cepro-examens-regroupement-encadrement-administration-logistique",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cepro-examens-regroupement-encadrement-administration-logistique",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "dependencies": {
         "@fullcalendar/core": "^6.1.19",
         "@fullcalendar/daygrid": "^6.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cepro-examens-regroupement-encadrement-administration-logistique",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Searching an exam by typing his code, name, teachers, or contact person.
Clicking on the exam opens his Modal and sends the user to the corresponding print week.

On the `exams` table, I also added a `None` option as responsible for when the exam does not have a responsible yet.