### PR TITLE
[feature] delete folder when deleting exam

### DIFF
--- a/app/api/delete-exam-folder/route.ts
+++ b/app/api/delete-exam-folder/route.ts
@@ -32,6 +32,19 @@ export async function DELETE(req: NextRequest) {
     });
   } catch (err) {
     console.error(err);
+
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      return NextResponse.json(
+        { error: "Exam folder not found", code: "FOLDER_NOT_FOUND" },
+        { status: 404 }
+      );
+    }
+
     return NextResponse.json(
       { error: "Failed to delete exam folder" },
       { status: 500 }

--- a/app/api/delete-exam-folder/route.ts
+++ b/app/api/delete-exam-folder/route.ts
@@ -1,0 +1,40 @@
+// app/api/delete-exam-folder/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { deleteExamFolder } from "@/app/lib/crep/upload";
+import { auth } from "@/auth";
+
+// ensure Node.js runtime (needed for fs / NAS)
+export const runtime = "nodejs";
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+
+  const folder_name = formData.get("folder_name");
+
+  if (!folder_name || typeof folder_name !== "string") {
+    return NextResponse.json(
+      { error: "Missing folder_name" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await deleteExamFolder(folder_name);
+
+    return NextResponse.json({
+      folder_name,
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Failed to delete exam folder" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -181,14 +181,32 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
         );
     }
 
-    async function handleDeleteExam(examId: string) {
+    async function handleDeleteExam(examId: string, folderName: string, selectStatus:string) {
         if(!examId) return;
 
-        if (!window.confirm("This will delete the exam from the database. Are you sure you want to proceed ?")) {
+        const shouldDeleteFolder = ["registered", "registered-warning", "registered-error", "toPrint"].includes(selectStatus)
+
+        if (!window.confirm(`This will delete the exam from the database. ${shouldDeleteFolder ? "The exam folder will also be deleted." : ""} Are you sure you want to proceed ?`)) {
             return;
         }
 
         await deleteCrepExam(examId);
+
+        if(shouldDeleteFolder) {
+            const formData = new FormData();
+            formData.append("folder_name", folderName || '');
+
+            const res = await fetch("/api/delete-exam-folder", {
+                method: "DELETE",
+                body: formData,
+            });
+            if (!res.ok) {
+                console.error(await res.text());
+                window.alert("An error occurred while deleting the exam folder. Please try again.");
+                return;
+            }
+        }
+
         event?.remove();
         setExams((currentExams: EventInput) => Array.isArray(currentExams)
             ? currentExams.filter((exam: EventInput) => String(exam.id) !== String(examId))
@@ -416,7 +434,7 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                     {/* Displays a dropdown if user has admin privileges */}
                     {user.isAdmin && (
                         <>                        
-                            <button type="button" className="btn btn-primary" onClick={() => handleDeleteExam(event?.id || '')}>Delete</button>
+                            <button type="button" className="btn btn-primary" onClick={() => handleDeleteExam(event?.id || '', event?.extendedProps?.folderName, selectStatus)}>Delete</button>
                             <select name="from" className="dropdown btn btn-secondary" id="from"
                                 value={selectStatus}
                                 onChange={(e) => setSelectStatus(e.target.value)}

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -181,6 +181,15 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
         );
     }
 
+    function removeExamFromCalendar(examId: string) {
+        event?.remove();
+        setExams((currentExams: EventInput) => Array.isArray(currentExams)
+            ? currentExams.filter((exam: EventInput) => String(exam.id) !== String(examId))
+            : currentExams
+        );
+        (document.getElementById("modal") as HTMLDialogElement | null)?.close();
+    }
+
     async function handleDeleteExam(examId: string, folderName: string, selectStatus:string) {
         if(!examId) return;
 
@@ -189,8 +198,6 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
         if (!window.confirm(`This will delete the exam from the database. ${shouldDeleteFolder ? "The exam folder will also be deleted." : ""} Are you sure you want to proceed ?`)) {
             return;
         }
-
-        await deleteCrepExam(examId);
 
         if(shouldDeleteFolder) {
             const formData = new FormData();
@@ -201,18 +208,25 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                 body: formData,
             });
             if (!res.ok) {
-                console.error(await res.text());
+                const error = await res.json().catch(() => null);
+                if (res.status === 404 && error?.code === "FOLDER_NOT_FOUND") {
+                    if (!window.confirm("The folder of this exam can not be found, do you want to delete the exam only from the database ?")) {
+                        return;
+                    }
+
+                    await deleteCrepExam(examId);
+                    removeExamFromCalendar(examId);
+                    return;
+                }
+
+                console.error(error);
                 window.alert("An error occurred while deleting the exam folder. Please try again.");
                 return;
             }
         }
 
-        event?.remove();
-        setExams((currentExams: EventInput) => Array.isArray(currentExams)
-            ? currentExams.filter((exam: EventInput) => String(exam.id) !== String(examId))
-            : currentExams
-        );
-        (document.getElementById("modal") as HTMLDialogElement | null)?.close();
+        await deleteCrepExam(examId);
+        removeExamFromCalendar(examId);
     }
 
     // Get color of selected exam

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -181,7 +181,7 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
         );
     }
 
-    async function handleDeleteExam(examId?: string) {
+    async function handleDeleteExam(examId: string) {
         if(!examId) return;
 
         if (!window.confirm("This will delete the exam from the database. Are you sure you want to proceed ?")) {
@@ -416,7 +416,7 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                     {/* Displays a dropdown if user has admin privileges */}
                     {user.isAdmin && (
                         <>                        
-                            <button type="button" className="btn btn-primary" onClick={() => handleDeleteExam(event?.id)}>Delete</button>
+                            <button type="button" className="btn btn-primary" onClick={() => handleDeleteExam(event?.id || '')}>Delete</button>
                             <select name="from" className="dropdown btn btn-secondary" id="from"
                                 value={selectStatus}
                                 onChange={(e) => setSelectStatus(e.target.value)}

--- a/app/lib/crep/upload.ts
+++ b/app/lib/crep/upload.ts
@@ -1,5 +1,5 @@
 // app/lib/upload-exam-files.ts
-import {mkdir, unlink, writeFile} from "fs/promises";
+import {mkdir, rm, unlink, writeFile} from "fs/promises";
 import path from "path";
 import { CrepExam } from "@/types/crepExam";
 import { formatDateOnlyValue } from "../dateTime";
@@ -56,4 +56,18 @@ export async function uploadExamFiles(
     console.log("saved pathes:",savedPaths.toString());
 
     return savedPaths;
+}
+
+export async function deleteExamFolder(
+    folder_name: string
+): Promise<void>  {
+    if (!examsFilesBasePath) {
+        throw new Error("EXAM_FILES_UPLOAD_FOLDER is not set in environment variables");
+    }
+    const examDir = path.join(examsFilesBasePath, folder_name);
+    console.log("Exam Dir :", examDir.toString());
+
+    await rm(examDir, {recursive: true});
+    console.log("folder deleted!");
+
 }


### PR DESCRIPTION
- `/api/delete-exam-folder` route
- Deleting folder only if status is `registered`, `registered-warning`, `registered-error` or `toPrint`
- If folder is not found, still offering the possibility to delete only from the database

close #183 