### PR TITLE
[feature/refactor] No more academic year and section selection

### DIFF
--- a/app/components/forms/teachersExamForm.tsx
+++ b/app/components/forms/teachersExamForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 // This form allows users to register their exams into the system.
-import { useForm, SubmitHandler, useFieldArray, Controller } from "react-hook-form"
-import { getAllExamTypes, getAllServices, insertExam, getAllSections, getServiceById } from "@/app/lib/database";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useForm, SubmitHandler, useFieldArray } from "react-hook-form"
+import { getAllExamTypes, getAllServices, insertExam, getServiceById } from "@/app/lib/database";
+import { useEffect, useState } from "react";
 import ReactSelect from "./ReactSelect";
 import { sendMail } from "@/app/lib/mail";
 import { User } from "next-auth";
@@ -11,9 +11,6 @@ import { RegisterModal } from "./RegisterModal";
 import { Inputs } from "@/types/inputs";
 import { Service } from "@/types/service";
 import { ExamType } from "@/types/examType";
-import Select from "react-select";
-import { GroupBase, StylesConfig, Theme } from "react-select";
-import { FormattedSection } from "@/types/section";
 import { fetchPersonBySciper } from "@/app/lib/api";
 import { getCurrentAcademicYear } from "@/app/lib/academicYear";
 
@@ -35,7 +32,6 @@ export default function App({ user }: RegisterProps) {
     const [isConfirmModal, setIsConfirmModal] = useState(false);
     const [services, setServices] = useState<Service[]>([]);
     const [examTypes, setExamTypes] = useState<ExamType[]>([]);
-    const [sections, setSections] = useState<FormattedSection[]>([]);
 
     useEffect(() => {
         (async () => {
@@ -44,14 +40,11 @@ export default function App({ user }: RegisterProps) {
 
             const allExamTypes = await getAllExamTypes();
             setExamTypes(allExamTypes);
-
-            const allSections = await getAllSections();
-            setSections(allSections);
             
         })();
     }, [])
 
-    const { control, register, handleSubmit, reset, setValue } = useForm<Inputs>({
+    const { control, register, handleSubmit, reset } = useForm<Inputs>({
         defaultValues: {
             examType: [],
         }
@@ -150,7 +143,6 @@ export default function App({ user }: RegisterProps) {
                         nb_pages: null,
                         total_pages: null,
                         remark: data.remark,
-                        section_id: data.section.section.id,
                         responsible_id: null,
                         contact: data.contact
                     }
@@ -206,50 +198,6 @@ CePro
             openModal("Unexpected Error", 'An unexpected error occurred while registering the exam.');
         }
     }
-    
-    const theme = useCallback((themeArg: Theme): Theme => {
-        return {
-            ...themeArg,
-            borderRadius: 9,
-            colors: {
-                ...themeArg.colors,
-                primary25: "rgba(239, 68, 68, 0.1)",
-                primary: "rgba(239, 68, 68, 1)",
-            },
-            fontWeight: "bolder" as unknown as Theme["spacing"],
-            fontSize: "24px" as unknown as Theme["spacing"],
-        } as Theme;
-    }, []);
-
-    function makeCustomStyles<Option, IsMulti extends boolean = boolean>(): StylesConfig<
-        Option,
-        IsMulti,
-        GroupBase<Option>
-    > {
-        return {
-            control: (styles) => ({
-            ...styles,
-            backgroundColor: "white",
-            ":focus-within": {
-                borderColor: "red",
-                boxShadow: "0 0 0 1px red",
-            },
-            padding: "4px",
-            }),
-            multiValueLabel: (styles) => ({
-            ...styles,
-            fontWeight: "500",
-            }),
-            option: (styles, { isSelected }) => ({
-            ...styles,
-            fontWeight: isSelected ? "600" : "normal",
-            }),
-        };
-    }
-
-    const sectionStyles = useMemo(() => 
-        makeCustomStyles<FormattedSection, false>(), []
-    )
 
     return (
         /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
@@ -306,25 +254,6 @@ CePro
                 </div>
                 <label>Select your exam <RedAsterisk /></label>
                 <ReactSelect control={control} label={"course"} name={"course"} isMultiChoice={false} containCourses={true} instanceId={1} />
-                <label>Exam section <RedAsterisk /></label>
-                <Controller
-                    name="section"
-                    control={control}
-                    render={({ field }) => (
-                        <Select<FormattedSection, false>
-                            instanceId="section"
-                            options={sections}
-                            styles={sectionStyles}
-                            theme={theme}
-                            value={field.value}
-                            onChange={(val) => field.onChange(val)}
-                            onBlur={field.onBlur}
-                            ref={field.ref}
-                            isClearable
-                            isSearchable
-                        />
-                    )}
-                />
                 <label>Exam type <RedAsterisk /></label>
                 {fields.map((field, index) => (
                     <div className="flex flex-row justify-between w-full 2xl:w-4/5 [&>*>label]:text-lg" key={field.id}>

--- a/app/components/forms/teachersExamForm.tsx
+++ b/app/components/forms/teachersExamForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 // This form allows users to register their exams into the system.
 import { useForm, SubmitHandler, useFieldArray, Controller } from "react-hook-form"
-import { getAllExamTypes, getAllServices, insertExam, getAllAcademicYears, getAllSections, getServiceById } from "@/app/lib/database";
+import { getAllExamTypes, getAllServices, insertExam, getAllSections, getServiceById } from "@/app/lib/database";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactSelect from "./ReactSelect";
 import { sendMail } from "@/app/lib/mail";
@@ -11,11 +11,11 @@ import { RegisterModal } from "./RegisterModal";
 import { Inputs } from "@/types/inputs";
 import { Service } from "@/types/service";
 import { ExamType } from "@/types/examType";
-import { FormattedAcademicYear } from "@/types/academicYear";
 import Select from "react-select";
 import { GroupBase, StylesConfig, Theme } from "react-select";
 import { FormattedSection } from "@/types/section";
 import { fetchPersonBySciper } from "@/app/lib/api";
+import { getCurrentAcademicYear } from "@/app/lib/academicYear";
 
 interface RegisterProps {
     user: AppUser
@@ -35,8 +35,6 @@ export default function App({ user }: RegisterProps) {
     const [isConfirmModal, setIsConfirmModal] = useState(false);
     const [services, setServices] = useState<Service[]>([]);
     const [examTypes, setExamTypes] = useState<ExamType[]>([]);
-    const [academicYears, setAcademicYears] = useState<FormattedAcademicYear[]>([]);
-    const [selectedAcademicYear, setSelectedAcademicYear] = useState<string>();
     const [sections, setSections] = useState<FormattedSection[]>([]);
 
     useEffect(() => {
@@ -46,9 +44,6 @@ export default function App({ user }: RegisterProps) {
 
             const allExamTypes = await getAllExamTypes();
             setExamTypes(allExamTypes);
-
-            const allAcademicYears = await getAllAcademicYears();
-            setAcademicYears(allAcademicYears.reverse()); // .reverse() to get the most recent academic years first in the list.
 
             const allSections = await getAllSections();
             setSections(allSections);
@@ -61,13 +56,6 @@ export default function App({ user }: RegisterProps) {
             examType: [],
         }
     })
-
-    useEffect(() => {
-        if (!academicYears.length) return;
-
-        setValue("academicYear", academicYears[0], { shouldValidate: true, shouldDirty: false });
-        setSelectedAcademicYear(academicYears[0].academicYear.code);
-    }, [academicYears, setValue]);
 
     useEffect(() => {
         if (!examTypes.length) return;
@@ -156,7 +144,7 @@ export default function App({ user }: RegisterProps) {
                         exam_type_id: examType.id,
                         exam_status_id: 2,
                         exam_date: examType.dontKnowYet ? null : examType.date,
-                        academic_year_id: data.academicYear.academicYear.id,
+                        academic_year_id: getCurrentAcademicYear(),
                         exam_semester: parseInt(data.examSemester),
                         nb_students: null,
                         nb_pages: null,
@@ -259,10 +247,6 @@ CePro
         };
     }
 
-    const academicYearStyles = useMemo(() => 
-        makeCustomStyles<FormattedAcademicYear, false>(), []
-    )
-
     const sectionStyles = useMemo(() => 
         makeCustomStyles<FormattedSection, false>(), []
     )
@@ -298,28 +282,6 @@ CePro
                 {/* register your input into the hook by invoking the "register" function */}
                 <label>Your email address</label>
                 <ReactSelect control={control} label={"registeredBy"} name={"contact"} isMultiChoice={false} instanceId={2} user={user} disabled={true}/>
-                <label>Academic Year <RedAsterisk /></label>
-                <Controller
-                    name="academicYear"
-                    control={control}
-                    render={({ field }) => (
-                        <Select<FormattedAcademicYear, false>
-                            instanceId="academicYear"
-                            options={academicYears}
-                            styles={academicYearStyles}
-                            theme={theme}
-                            value={field.value}
-                            onChange={(val) => {
-                                field.onChange(val)
-                                setSelectedAcademicYear(val?.academicYear.code)
-                            }}
-                            onBlur={field.onBlur}
-                            ref={field.ref}
-                            isClearable
-                            isSearchable
-                        />
-                    )}
-                />
                 <label>Exam semester <RedAsterisk /></label>
                 <div className="flex gap-1" key={1}>
                         <input
@@ -343,7 +305,7 @@ CePro
                         <label className="!text-sm" htmlFor="semester-2">Semester 2</label>
                 </div>
                 <label>Select your exam <RedAsterisk /></label>
-                <ReactSelect key={selectedAcademicYear} control={control} label={"course"} name={"course"} isMultiChoice={false} containCourses={true} instanceId={1} academicYear={selectedAcademicYear} />
+                <ReactSelect control={control} label={"course"} name={"course"} isMultiChoice={false} containCourses={true} instanceId={1} />
                 <label>Exam section <RedAsterisk /></label>
                 <Controller
                     name="section"

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -58,7 +58,7 @@ export async function insertExam(exam: NewExam): Promise<number> {
     connection.connect();
 
     return new Promise((resolve, reject) => {
-        const sql = `INSERT INTO exam (code, name, service_level_id, service_id, exam_type_id, exam_status_id, exam_date, academic_year_id, exam_semester, nb_students, nb_pages, total_pages, remark, section_id, responsible_id, contact) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
+        const sql = `INSERT INTO exam (code, name, service_level_id, service_id, exam_type_id, exam_status_id, exam_date, academic_year_id, exam_semester, nb_students, nb_pages, total_pages, remark, responsible_id, contact) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`;
 
         const params = [
             exam.code,
@@ -76,7 +76,6 @@ export async function insertExam(exam: NewExam): Promise<number> {
             // exam.deadline_prep,
             // exam.deadline_repro,
             exam.remark || null,
-            exam.section_id,
             exam.responsible_id,
             exam.contact,
         ];

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -194,7 +194,7 @@ export async function getExamsByAcademicYear(academicYear: string): Promise <Exa
     connection.connect()
     
     return new Promise(function(resolve) {
-        connection.query('SELECT exam.* FROM exam LEFT JOIN academic_year ON exam.academic_year_id = academic_year.id WHERE academic_year.code = ?;', [academicYear], (err, rows) => {
+        connection.query('SELECT exam.* FROM exam WHERE exam.academic_year_id = ?;', [academicYear], (err, rows) => {
             if (err) throw err
             resolve(rows as Exam[]);
         })

--- a/types/exam.ts
+++ b/types/exam.ts
@@ -15,7 +15,6 @@ export type Exam = {
     // deadline_prep: string | Date;
     // deadline_repro: string | Date;
     remark?: string | null;
-    section_id: number;
     responsible_id: number | null;
     contact: string;
 }

--- a/types/exam.ts
+++ b/types/exam.ts
@@ -7,7 +7,7 @@ export type Exam = {
     exam_type_id: number;
     exam_status_id: number;
     exam_date?: string | Date | null;
-    academic_year_id: number;
+    academic_year_id: string;
     exam_semester: number;
     nb_students?: number | null;
     nb_pages?: number | null;


### PR DESCRIPTION
- No need to select the academic year anymore (The registered exam's academic year is considered as the current one, no more constraint in the database, `academic_year_id`  value is now the academic year code (ex. `2025-2026`)
- Neither the section (considered as useless, deleted the column from the database)

close #180 