### PR TITLE
[feature] Email templates

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -13,7 +13,7 @@ import {
     getDatePartFromDateTimeString,
     getTimePartFromDateTimeString,
 } from "../lib/dateTime";
-import { sendMail } from "../lib/mail";
+import { sendTemplatedMail } from "../lib/mail";
 import { AuthorizedPersons } from "@/types/user";
 import { limitTextToLines } from "../lib/remarks";
 
@@ -521,45 +521,24 @@ export function Modal({ event, user, examStatus, exams, setExams }: ModalProps) 
                             if (process.env.NODE_ENV !== "development") {
                                 const datePrintSchedule = new Date(event?.extendedProps?.printSchedule)
                                 const examURL = `https://cereal.epfl.ch/crep/?openExamId=${event?.id}&day=${formatDateYYYYMMDD(datePrintSchedule)}`;
-                                await sendMail(
-                                    'examen.repro@epfl.ch',
-                                    `Exam ${event?.extendedProps?.code} is ready to be printed`,
-                                    `
-Hello,
-
-The exam ${event?.extendedProps?.description} status has been set to "toPrint" in CREP.
-
-You can see the exam in the app directly by clicking on this link : ${examURL}
-
-Best,
-CePro team
-`,
-                                    ''
-                                );
+                                await sendTemplatedMail("exam_ready_to_print", {
+                                    examCode: event?.extendedProps?.code,
+                                    description: event?.extendedProps?.description,
+                                    examURL,
+                                });
                             }
                         }
 
                         if (shouldNotifyFinished) {
                             const authorizedPersonsEmails = event?.extendedProps?.authorizedPersons.map((e:AuthorizedPersons) => e.email).join(', ')
                             if (process.env.NODE_ENV !== "development") {
-                                await sendMail(
-                                    event?.extendedProps?.contact.email,
-                                    `Exam ${event?.extendedProps?.code} is ready to be picked up`,
-                                    `
-Hello,
-
-The exam ${event?.extendedProps?.description} has been finished printing and is ready to be picked up at the Repro.
-Number of boxes : ${boxes}
-
-Click on this link to find where the Repro is located : https://plan.epfl.ch/?room=%253DBP%200243
-Click on this link to see the Repro's opening hours : https://www.epfl.ch/campus/services/repro/fr/contacts/#ancre2
-
-Best,
-CePro team
-`,
-                                    authorizedPersonsEmails,
-                                    'examen.repro@epfl.ch'
-                                );
+                                await sendTemplatedMail("exam_ready_to_pickup", {
+                                    examCode: event?.extendedProps?.code,
+                                    description: event?.extendedProps?.description,
+                                    boxes,
+                                    "contact.email": event?.extendedProps?.contact.email,
+                                    authorizedPersons: authorizedPersonsEmails,
+                                });
                             }
                         }
 

--- a/app/components/admin/AdminPage.tsx
+++ b/app/components/admin/AdminPage.tsx
@@ -5,19 +5,23 @@ import {
   deleteExamStatus,
   deleteService,
   deleteServiceLevel,
+  getAllEmailTemplates,
   getAllExamStatus,
   getAllServiceLevels,
   getAllServices,
   insertExamStatus,
   insertService,
   insertServiceLevel,
+  updateEmailTemplate,
 } from "@/app/lib/database";
+import { EMAIL_TEMPLATES, EmailTemplateKey } from "@/app/lib/emailTemplates";
+import { EmailTemplate } from "@/types/emailTemplate";
 import { ExamStatus } from "@/types/examStatus";
 import { Service } from "@/types/service";
 import { ServiceLevel } from "@/types/serviceLevel";
 
-type Tab = "service" | "serviceLevel" | "examStatus";
-type AddModalType = Tab;
+type Tab = "service" | "serviceLevel" | "examStatus" | "emailTemplate";
+type AddModalType = Exclude<Tab, "emailTemplate">;
 
 const addModalConfig: Record<AddModalType, {
   title: string;
@@ -45,6 +49,30 @@ const addModalConfig: Record<AddModalType, {
   },
 };
 
+type TemplateFormFields = {
+  subject: string;
+  body: string;
+  recipients_to: string;
+  recipients_cc: string;
+  reply_to: string;
+};
+
+const emptyTemplateForm: TemplateFormFields = {
+  subject: "",
+  body: "",
+  recipients_to: "",
+  recipients_cc: "",
+  reply_to: "",
+};
+
+const templateFieldLabels: { key: keyof TemplateFormFields; label: string; multiline?: boolean }[] = [
+  { key: "subject", label: "Subject" },
+  { key: "body", label: "Body", multiline: true },
+  { key: "recipients_to", label: "To" },
+  { key: "recipients_cc", label: "Cc" },
+  { key: "reply_to", label: "Reply-To" },
+];
+
 export default function AdminPage() {
   const [activeTab, setActiveTab] = React.useState<Tab>("service");
   const [services, setServices] = React.useState<Service[]>([]);
@@ -56,6 +84,13 @@ export default function AdminPage() {
   const [newColor, setNewColor] = React.useState("#9a9a9a");
   const [isAdding, setIsAdding] = React.useState(false);
   const [addError, setAddError] = React.useState("");
+  const [emailTemplates, setEmailTemplates] = React.useState<EmailTemplate[]>([]);
+  const [editingTemplate, setEditingTemplate] = React.useState<EmailTemplate | null>(null);
+  const [templateForm, setTemplateForm] = React.useState<TemplateFormFields>(emptyTemplateForm);
+  const [savingTemplate, setSavingTemplate] = React.useState(false);
+  const [templateError, setTemplateError] = React.useState("");
+  const fieldRefs = React.useRef<Record<string, HTMLInputElement | HTMLTextAreaElement | null>>({});
+  const activeFieldKey = React.useRef<keyof TemplateFormFields>("body");
 
   async function handleDeleteService(service: Service) {
     if(window.confirm("This will delete this service from the database. Are you sure you want to continue ?")) {
@@ -155,17 +190,83 @@ export default function AdminPage() {
     setAddError("");
   }
 
+  function openEditTemplate(template: EmailTemplate) {
+    setEditingTemplate(template);
+    setTemplateForm({
+      subject: template.subject ?? "",
+      body: template.body ?? "",
+      recipients_to: template.recipients_to ?? "",
+      recipients_cc: template.recipients_cc ?? "",
+      reply_to: template.reply_to ?? "",
+    });
+    activeFieldKey.current = "body";
+    setTemplateError("");
+  }
+
+  function closeEditTemplate() {
+    setEditingTemplate(null);
+    setTemplateForm(emptyTemplateForm);
+    setTemplateError("");
+  }
+
+  function insertPlaceholder(token: string) {
+    const key = activeFieldKey.current;
+    const insert = `{{${token}}}`;
+    const el = fieldRefs.current[key];
+
+    setTemplateForm((prev) => {
+      const current = prev[key] ?? "";
+      if (el && typeof el.selectionStart === "number") {
+        const start = el.selectionStart;
+        const end = el.selectionEnd ?? start;
+        const next = current.slice(0, start) + insert + current.slice(end);
+        requestAnimationFrame(() => {
+          el.focus();
+          const pos = start + insert.length;
+          el.setSelectionRange(pos, pos);
+        });
+        return { ...prev, [key]: next };
+      }
+      return { ...prev, [key]: current + insert };
+    });
+  }
+
+  async function handleSaveTemplate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!editingTemplate) return;
+
+    setSavingTemplate(true);
+    setTemplateError("");
+
+    const updated: EmailTemplate = { ...editingTemplate, ...templateForm };
+
+    try {
+      await updateEmailTemplate(updated);
+      setEmailTemplates((current) =>
+        current.map((t) => (t.template_key === updated.template_key ? updated : t))
+      );
+      closeEditTemplate();
+    } catch (error) {
+      console.error(error);
+      setTemplateError("Unable to save this template. Please try again.");
+    } finally {
+      setSavingTemplate(false);
+    }
+  }
+
   React.useEffect(() => {
     (async () => {
-      const [allServices, allServiceLevels, allExamStatuses] = await Promise.all([
+      const [allServices, allServiceLevels, allExamStatuses, allEmailTemplates] = await Promise.all([
         getAllServices(),
         getAllServiceLevels(),
         getAllExamStatus(),
+        getAllEmailTemplates(),
       ]);
 
       setServices(allServices);
       setServiceLevels(allServiceLevels);
       setExamStatuses(allExamStatuses);
+      setEmailTemplates(allEmailTemplates);
     })();
   }, []);
 
@@ -189,6 +290,12 @@ export default function AdminPage() {
           onClick={() => setActiveTab("examStatus")}
         >
           Exam status
+        </TabButton>
+        <TabButton
+          active={activeTab === "emailTemplate"}
+          onClick={() => setActiveTab("emailTemplate")}
+        >
+          Emails
         </TabButton>
       </div>
 
@@ -361,6 +468,129 @@ export default function AdminPage() {
           >
             +
           </button>
+        </div>
+      )}
+
+      {activeTab === "emailTemplate" && (
+        <div className="grid gap-2">
+          {emailTemplates.map((template) => (
+            <div className="flex justify-between items-center rounded-lg border border-slate-200 p-3" key={template.template_key}>
+              <div className="flex flex-col">
+                <span className="font-medium text-slate-900">{template.name}</span>
+                <span className="text-xs text-slate-500">To: {template.recipients_to || "—"}</span>
+              </div>
+              <button
+                className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:cursor-pointer hover:bg-red-700 transition ease-in-out"
+                onClick={() => openEditTemplate(template)}
+                type="button"
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+          {emailTemplates.length === 0 && (
+            <p className="text-sm text-slate-500">No email templates found.</p>
+          )}
+        </div>
+      )}
+
+      {editingTemplate && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4"
+          role="presentation"
+        >
+          <form
+            aria-labelledby="edit-template-title"
+            className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg bg-white shadow-xl"
+            onSubmit={handleSaveTemplate}
+            role="dialog"
+          >
+            <div className="flex items-start justify-between gap-4 border-b border-slate-200 p-6">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-950" id="edit-template-title">
+                  {editingTemplate.name}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Customize the content and recipients of this email.
+                </p>
+              </div>
+              <button
+                aria-label="Close"
+                className="rounded-md px-2 py-1 text-xl leading-none text-slate-400 hover:cursor-pointer hover:bg-slate-100 hover:text-slate-700"
+                onClick={closeEditTemplate}
+                type="button"
+              >
+                x
+              </button>
+            </div>
+
+            <div className="grid gap-4 overflow-y-auto p-6">
+              {templateFieldLabels.map((field) => (
+                <label className="grid gap-1 text-sm font-medium text-slate-700" key={field.key}>
+                  {field.label}
+                  {field.multiline ? (
+                    <textarea
+                      className="min-h-64 rounded-md border border-slate-300 px-3 py-2 font-mono text-xs font-normal text-slate-950 outline-none focus:border-red-600 focus:ring-2 focus:ring-red-100"
+                      onChange={(event) => setTemplateForm((prev) => ({ ...prev, [field.key]: event.target.value }))}
+                      onFocus={() => { activeFieldKey.current = field.key; }}
+                      ref={(el) => { fieldRefs.current[field.key] = el; }}
+                      value={templateForm[field.key]}
+                    />
+                  ) : (
+                    <input
+                      className="rounded-md border border-slate-300 px-3 py-2 text-sm font-normal text-slate-950 outline-none focus:border-red-600 focus:ring-2 focus:ring-red-100"
+                      onChange={(event) => setTemplateForm((prev) => ({ ...prev, [field.key]: event.target.value }))}
+                      onFocus={() => { activeFieldKey.current = field.key; }}
+                      ref={(el) => { fieldRefs.current[field.key] = el; }}
+                      value={templateForm[field.key]}
+                    />
+                  )}
+                </label>
+              ))}
+
+              <div className="rounded-md bg-slate-50 p-3">
+                <p className="mb-2 text-xs font-semibold text-slate-700">
+                  Available placeholders (click to insert in the focused field)
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {EMAIL_TEMPLATES[editingTemplate.template_key as EmailTemplateKey]?.placeholders.map((placeholder) => (
+                    <button
+                      className="rounded border border-slate-300 bg-white px-2 py-1 font-mono text-xs text-slate-700 hover:cursor-pointer hover:border-red-500 hover:text-red-600"
+                      key={placeholder.token}
+                      onClick={() => insertPlaceholder(placeholder.token)}
+                      title={placeholder.desc}
+                      type="button"
+                    >
+                      {`{{${placeholder.token}}}`}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {templateError && (
+              <p className="mx-6 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {templateError}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2 border-t border-slate-200 p-6">
+              <button
+                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:cursor-pointer hover:bg-slate-50"
+                onClick={closeEditTemplate}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:cursor-pointer hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300"
+                disabled={savingTemplate}
+                type="submit"
+              >
+                {savingTemplate ? "Saving..." : "Save template"}
+              </button>
+            </div>
+          </form>
         </div>
       )}
     </main>

--- a/app/components/admin/AdminPage.tsx
+++ b/app/components/admin/AdminPage.tsx
@@ -12,6 +12,7 @@ import {
   insertExamStatus,
   insertService,
   insertServiceLevel,
+  syncEmailTemplates,
   updateEmailTemplate,
 } from "@/app/lib/database";
 import { EMAIL_TEMPLATES, EmailTemplateKey } from "@/app/lib/emailTemplates";
@@ -265,6 +266,8 @@ export default function AdminPage() {
 
   React.useEffect(() => {
     (async () => {
+      await syncEmailTemplates();
+
       const [allServices, allServiceLevels, allExamStatuses, allEmailTemplates] = await Promise.all([
         getAllServices(),
         getAllServiceLevels(),

--- a/app/components/admin/AdminPage.tsx
+++ b/app/components/admin/AdminPage.tsx
@@ -50,6 +50,7 @@ const addModalConfig: Record<AddModalType, {
 };
 
 type TemplateFormFields = {
+  name: string;
   subject: string;
   body: string;
   recipients_to: string;
@@ -58,6 +59,7 @@ type TemplateFormFields = {
 };
 
 const emptyTemplateForm: TemplateFormFields = {
+  name: "",
   subject: "",
   body: "",
   recipients_to: "",
@@ -66,6 +68,7 @@ const emptyTemplateForm: TemplateFormFields = {
 };
 
 const templateFieldLabels: { key: keyof TemplateFormFields; label: string; multiline?: boolean }[] = [
+  { key: "name", label: "Name" },
   { key: "subject", label: "Subject" },
   { key: "body", label: "Body", multiline: true },
   { key: "recipients_to", label: "To" },
@@ -198,6 +201,7 @@ export default function AdminPage() {
   function openEditTemplate(template: EmailTemplate) {
     setEditingTemplate(template);
     setTemplateForm({
+      name: template.name ?? "",
       subject: template.subject ?? "",
       body: template.body ?? "",
       recipients_to: template.recipients_to ?? "",

--- a/app/components/admin/AdminPage.tsx
+++ b/app/components/admin/AdminPage.tsx
@@ -91,6 +91,11 @@ export default function AdminPage() {
   const [templateError, setTemplateError] = React.useState("");
   const fieldRefs = React.useRef<Record<string, HTMLInputElement | HTMLTextAreaElement | null>>({});
   const activeFieldKey = React.useRef<keyof TemplateFormFields>("body");
+  const [collapsedSections, setCollapsedSections] = React.useState<Record<string, boolean>>({});
+
+  function toggleSection(section: string) {
+    setCollapsedSections((prev) => ({ ...prev, [section]: !prev[section] }));
+  }
 
   async function handleDeleteService(service: Service) {
     if(window.confirm("This will delete this service from the database. Are you sure you want to continue ?")) {
@@ -472,22 +477,39 @@ export default function AdminPage() {
       )}
 
       {activeTab === "emailTemplate" && (
-        <div className="grid gap-2">
-          {emailTemplates.map((template) => (
-            <div className="flex justify-between items-center rounded-lg border border-slate-200 p-3" key={template.template_key}>
-              <div className="flex flex-col">
-                <span className="font-medium text-slate-900">{template.name}</span>
-                <span className="text-xs text-slate-500">To: {template.recipients_to || "—"}</span>
+        <div className="grid gap-6">
+          {groupTemplatesBySection(emailTemplates).map(([section, templates]) => {
+            const collapsed = collapsedSections[section];
+            return (
+              <div className="grid gap-2" key={section}>
+                <button
+                  aria-expanded={!collapsed}
+                  className="flex items-center gap-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 hover:cursor-pointer hover:text-slate-900"
+                  onClick={() => toggleSection(section)}
+                  type="button"
+                >
+                  <span className={`inline-block transition-transform ${collapsed ? "" : "rotate-90"}`}>›</span>
+                  {section}
+                  <span className="font-normal normal-case text-slate-400">({templates.length})</span>
+                </button>
+                {!collapsed && templates.map((template) => (
+                  <div className="flex justify-between items-center rounded-lg border border-slate-200 p-3" key={template.template_key}>
+                    <div className="flex flex-col">
+                      <span className="font-medium text-slate-900">{template.name}</span>
+                      <span className="text-xs text-slate-500">To: {template.recipients_to || "—"}</span>
+                    </div>
+                    <button
+                      className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:cursor-pointer hover:bg-red-700 transition ease-in-out"
+                      onClick={() => openEditTemplate(template)}
+                      type="button"
+                    >
+                      Edit
+                    </button>
+                  </div>
+                ))}
               </div>
-              <button
-                className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:cursor-pointer hover:bg-red-700 transition ease-in-out"
-                onClick={() => openEditTemplate(template)}
-                type="button"
-              >
-                Edit
-              </button>
-            </div>
-          ))}
+            );
+          })}
           {emailTemplates.length === 0 && (
             <p className="text-sm text-slate-500">No email templates found.</p>
           )}
@@ -599,6 +621,21 @@ export default function AdminPage() {
 
 function isHexColor(value: string) {
   return /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+// Group templates by their section, preserving first-appearance order.
+function groupTemplatesBySection(templates: EmailTemplate[]): [string, EmailTemplate[]][] {
+  const groups = new Map<string, EmailTemplate[]>();
+  for (const template of templates) {
+    const section = template.section || "Other";
+    const existing = groups.get(section);
+    if (existing) {
+      existing.push(template);
+    } else {
+      groups.set(section, [template]);
+    }
+  }
+  return Array.from(groups.entries());
 }
 
 function TabButton({

--- a/app/components/crep/register.tsx
+++ b/app/components/crep/register.tsx
@@ -5,7 +5,7 @@ import { getAllExamsBetweenDates, getBlockingExamsForDate, insertExamForPrint } 
 import { useState } from "react";
 import ReactSelect from "../forms/ReactSelect";
 import { fetchMultiplePersonsBySciper, fetchPersonBySciper } from "@/app/lib/api";
-import { sendMail } from "@/app/lib/mail";
+import { sendTemplatedMail } from "@/app/lib/mail";
 import { fromDatabaseDateTime, formatDateTimeForDatabase, formatDateYYYYMMDD } from "@/app/lib/dateTime";
 import { User } from "next-auth";
 import { RedAsterisk } from "../RedAsterisk";
@@ -413,14 +413,8 @@ export default function App({ user }: RegisterProps) {
             If the status is `registered-error`, that means that a printing schedule could NOT be found, so the CePro (and Repro) team need to do something for the user. 
            */
             if (process.env.NODE_ENV !== "development") {
-                await sendMail(
-                    user.email || '',
-                    `${status == 'registered-warning' || status == 'registered-error' ? 'REQUIRES ATTENTION - ' : ''}CePro - Exam printing service subscription confirmation`,
-                    `
-Hello,
-Your subscription to our exam printing service has been registered:
-
-${['registered-warning', 'registered-error'].includes(status) ? `
+                const attentionRequired = ['registered-warning', 'registered-error'].includes(status);
+                const attentionBlock = attentionRequired ? `
 ⚠️ : ${
     status === 'registered-error'
         ? `Due to a printing planning extremely full or too tight delays, we could not determine a printing session for your exam.
@@ -429,17 +423,19 @@ The CePro team will get in touch with you as soon as possible to discuss about y
 The CePro team will get in touch with you shortly to discuss about your situation.
 Next time, please register to the printing service earlier to make sur that the printing team has the right amount of time to print your exam correctly.`
 }
-` : ''}
-
-- Course: ${data.course?.label}
-- Exam date: ${data.examDate}
-- Desired delivery date: ${data.desiredDate}
-- Contact: ${contact?.firstname} ${contact?.lastname} (${contact?.email})
-${authorizedPersons.length > 0 ? `- Authorized persons: ${authorizedPersons.map(user => `${user.email}`).join(', ')}` : ''}
-- Files: ${filesNamesArray.join(', ')}
-${data.remark && `- Additional remarks: ${data.remark}`}`,
-                    'cepro-exams@epfl.ch'
-                );
+` : '';
+                await sendTemplatedMail("crep_printing_confirmation", {
+                    attentionPrefix: attentionRequired ? 'REQUIRES ATTENTION - ' : '',
+                    attentionBlock,
+                    course: data.course?.label,
+                    examDate: data.examDate,
+                    desiredDate: data.desiredDate,
+                    contact: `${contact?.firstname} ${contact?.lastname} (${contact?.email})`,
+                    authorizedPersonsLine: authorizedPersons.length > 0 ? `- Authorized persons: ${authorizedPersons.map(user => `${user.email}`).join(', ')}` : '',
+                    files: filesNamesArray.join(', '),
+                    remarkLine: data.remark ? `- Additional remarks: ${data.remark}` : '',
+                    "registrant.email": user.email || '',
+                });
             }
             if(status == 'registered-warning') {
                 // Modal with warning that there is less than 8 days between the exam date and the desired delivery date.

--- a/app/components/forms/teachersExamForm.tsx
+++ b/app/components/forms/teachersExamForm.tsx
@@ -4,7 +4,7 @@ import { useForm, SubmitHandler, useFieldArray } from "react-hook-form"
 import { getAllExamTypes, getAllServices, insertExam, getServiceById } from "@/app/lib/database";
 import { useEffect, useState } from "react";
 import ReactSelect from "./ReactSelect";
-import { sendMail } from "@/app/lib/mail";
+import { sendTemplatedMail } from "@/app/lib/mail";
 import { User } from "next-auth";
 import { RedAsterisk } from "../RedAsterisk";
 import { RegisterModal } from "./RegisterModal";
@@ -165,44 +165,24 @@ export default function App({ user }: RegisterProps) {
                     return;
                 }
             }
-            if (process.env.NODE_ENV !== "development") {
-                await sendMail(
-                    user.email || '',
-                    `CePro - exam services subscription confirmation`,
-                    `
-Hello,
-Your subscription to our exam services has been successfully registered:
-
-- Course: ${data.course.exam.code}
-- Teacher${data.course.exam.teachers.length > 1 ? 's' : ''}: ${data.course.exam.teachers.map((t) => `${t.firstname} ${t.name}${t.sciper ? ` (${t.sciper})` : ''}`).join(', ')}
-- Contact: ${contact.email}
-- Type${data.examType.filter((examType) => examType.checked).length > 1 ? 's' : ''} of exam: ${data.examType.filter((examType) => examType.checked).map((examType) => examType.name).join(', ')}
-- Service: ${service[0].description}
-- Level of service: Silver
-- Date of exam:
-${data.examType
-  .filter((examType) => examType.checked)
-  .map(
-    (examType) =>
-      `    - ${examType.name} : ${
-        examType.dontKnowYet ? `Don't know yet` : examType.date
-      }`
-  )
-  .join('\n')}
-- Remarks: ${data.remark}
-
-If you have asked to discuss with us which service to use, we will get back to you shortly.
-Your comments will also be taken into account and we will do what is necessary to take them into account and keep you informed if necessary.
-
-You can already browse our moodle pages, which contain all the information you need to prepare and organise your exam.
-https://moodle.epfl.ch/course/view.php?id=16420
-
-Best
-
-CePro
-`,
-                    'cepro-exams@epfl.ch'
-                );
+            if (process.env.NODE_ENV == "development") {
+                await sendTemplatedMail("exam_services_confirmation", {
+                    course: data.course.exam.code,
+                    teachers: data.course.exam.teachers.map((t) => `${t.firstname} ${t.name}${t.sciper ? ` (${t.sciper})` : ''}`).join(', '),
+                    contactEmail: contact.email,
+                    examTypes: data.examType.filter((examType) => examType.checked).map((examType) => examType.name).join(', '),
+                    service: service[0].description,
+                    serviceLevel: "Silver",
+                    examDates: data.examType
+                        .filter((examType) => examType.checked)
+                        .map(
+                            (examType) =>
+                                `    - ${examType.name} : ${examType.dontKnowYet ? `Don't know yet` : examType.date}`
+                        )
+                        .join('\n'),
+                    remark: data.remark,
+                    "registrant.email": user.email || '',
+                });
             }
             openModal("Registration Successful", 'Your Exam ' + data.course.exam.code + ' has been registered and a confirmation has been sent to your email.');
             reset();

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -7,6 +7,7 @@ import { Exam, NewExam } from '@/types/exam';
 import { ServiceLevel } from '@/types/serviceLevel';
 import { ExamStatus } from '@/types/examStatus';
 import { EmailTemplate } from '@/types/emailTemplate';
+import { EMAIL_TEMPLATES } from '@/app/lib/emailTemplates';
 
 export async function getAllServices(): Promise <Service[]> {
     const connection = mysql.createConnection({
@@ -530,6 +531,81 @@ export async function deleteExam(examId: string) {
             resolve(JSON.stringify(rows));
         })
         connection.end()
+    })
+}
+
+// Reconcile the email_template table with the EMAIL_TEMPLATES registry, which is
+// the source of truth:
+//  - INSERT the templates that are actually missing (existing rows, including
+//    admin customizations, are left untouched);
+//  - DELETE the rows whose template_key is no longer in the registry (an email
+//    removed from the code disappears from the DB and the admin UI).
+// Adding/removing an email therefore only requires a registry change + call site,
+// with no manual SQL in production. We insert only the missing rows (rather than
+// INSERT IGNORE everything) so the common case writes nothing and does not burn
+// AUTO_INCREMENT ids on every page load.
+export async function syncEmailTemplates() {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    const keys = Object.keys(EMAIL_TEMPLATES)
+
+    return new Promise<void>((resolve, reject) => {
+        connection.query('SELECT template_key FROM email_template;', (selectErr, rows) => {
+            if (selectErr) {
+                connection.end()
+                return reject(selectErr)
+            }
+
+            const existing = new Set((rows as { template_key: string }[]).map((row) => row.template_key))
+            const toInsert = Object.entries(EMAIL_TEMPLATES)
+                .filter(([key]) => !existing.has(key))
+                .map(([key, def]) => [
+                    key,
+                    def.section,
+                    def.name,
+                    def.defaults.subject,
+                    def.defaults.body,
+                    def.defaults.to,
+                    def.defaults.cc,
+                    def.defaults.replyTo,
+                ])
+
+            const runDelete = () => {
+                connection.query(
+                    'DELETE FROM email_template WHERE template_key NOT IN (?);',
+                    [keys],
+                    (deleteErr) => {
+                        connection.end()
+                        if (deleteErr) return reject(deleteErr)
+                        resolve()
+                    }
+                )
+            }
+
+            if (toInsert.length === 0) {
+                runDelete()
+                return
+            }
+
+            connection.query(
+                'INSERT INTO email_template (template_key, section, name, subject, body, recipients_to, recipients_cc, reply_to) VALUES ?;',
+                [toInsert],
+                (insertErr) => {
+                    if (insertErr) {
+                        connection.end()
+                        return reject(insertErr)
+                    }
+                    runDelete()
+                }
+            )
+        })
     })
 }
 

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -584,8 +584,8 @@ export async function updateEmailTemplate(template: EmailTemplate) {
 
     return new Promise((resolve, reject) => {
         connection.query(
-            'UPDATE email_template SET subject = ?, body = ?, recipients_to = ?, recipients_cc = ?, reply_to = ? WHERE template_key = ?;',
-            [template.subject, template.body, template.recipients_to, template.recipients_cc, template.reply_to, template.template_key],
+            'UPDATE email_template SET name = ?, subject = ?, body = ?, recipients_to = ?, recipients_cc = ?, reply_to = ? WHERE template_key = ?;',
+            [template.name, template.subject, template.body, template.recipients_to, template.recipients_cc, template.reply_to, template.template_key],
             (err, rows) => {
                 if (err) return reject(err)
                 resolve(JSON.stringify(rows));

--- a/app/lib/database.ts
+++ b/app/lib/database.ts
@@ -6,6 +6,7 @@ import { ExamType } from '@/types/examType';
 import { Exam, NewExam } from '@/types/exam';
 import { ServiceLevel } from '@/types/serviceLevel';
 import { ExamStatus } from '@/types/examStatus';
+import { EmailTemplate } from '@/types/emailTemplate';
 
 export async function getAllServices(): Promise <Service[]> {
     const connection = mysql.createConnection({
@@ -528,6 +529,68 @@ export async function deleteExam(examId: string) {
             if (err) throw err
             resolve(JSON.stringify(rows));
         })
+        connection.end()
+    })
+}
+
+export async function getAllEmailTemplates(): Promise<EmailTemplate[]> {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    return new Promise(function(resolve) {
+        connection.query('SELECT * FROM email_template ORDER BY id;', (err, rows) => {
+            if (err) throw err
+            resolve(rows as EmailTemplate[]);
+        })
+        connection.end()
+    })
+}
+
+export async function getEmailTemplate(templateKey: string): Promise<EmailTemplate | null> {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    return new Promise(function(resolve) {
+        connection.query('SELECT * FROM email_template WHERE template_key = ?;', [templateKey], (err, rows) => {
+            if (err) throw err
+            const templates = rows as EmailTemplate[]
+            resolve(templates.length > 0 ? templates[0] : null);
+        })
+        connection.end()
+    })
+}
+
+export async function updateEmailTemplate(template: EmailTemplate) {
+    const connection = mysql.createConnection({
+        host: process.env.MYSQL_HOST,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    connection.connect()
+
+    return new Promise((resolve, reject) => {
+        connection.query(
+            'UPDATE email_template SET subject = ?, body = ?, recipients_to = ?, recipients_cc = ?, reply_to = ? WHERE template_key = ?;',
+            [template.subject, template.body, template.recipients_to, template.recipients_cc, template.reply_to, template.template_key],
+            (err, rows) => {
+                if (err) return reject(err)
+                resolve(JSON.stringify(rows));
+            }
+        )
         connection.end()
     })
 }

--- a/app/lib/emailTemplates.ts
+++ b/app/lib/emailTemplates.ts
@@ -1,0 +1,168 @@
+export type Placeholder = {
+    token: string;
+    desc: string;
+};
+
+export type TemplateDefinition = {
+    name: string;
+    placeholders: Placeholder[];
+    defaults: {
+        subject: string;
+        body: string;
+        to: string;
+        cc: string;
+        replyTo: string;
+    };
+};
+
+export type EmailTemplateKey =
+    | "exam_services_confirmation"
+    | "crep_printing_confirmation"
+    | "exam_ready_to_print"
+    | "exam_ready_to_pickup";
+
+export const EMAIL_TEMPLATES: Record<EmailTemplateKey, TemplateDefinition> = {
+    exam_services_confirmation: {
+        name: "Exam services subscription confirmation",
+        placeholders: [
+            { token: "course", desc: "Course code" },
+            { token: "teachers", desc: "Teachers list" },
+            { token: "contactEmail", desc: "Contact email" },
+            { token: "examTypes", desc: "Selected exam types" },
+            { token: "service", desc: "Service description" },
+            { token: "serviceLevel", desc: "Service level" },
+            { token: "examDates", desc: "Exam dates per type (multi-line)" },
+            { token: "remark", desc: "Remarks" },
+            { token: "registrant.email", desc: "Registrant email (recipient)" },
+        ],
+        defaults: {
+            subject: "CePro - exam services subscription confirmation",
+            body: `
+Hello,
+Your subscription to our exam services has been successfully registered:
+
+- Course: {{course}}
+- Teacher(s): {{teachers}}
+- Contact: {{contactEmail}}
+- Type(s) of exam: {{examTypes}}
+- Service: {{service}}
+- Level of service: {{serviceLevel}}
+- Date of exam:
+{{examDates}}
+- Remarks: {{remark}}
+
+If you have asked to discuss with us which service to use, we will get back to you shortly.
+Your comments will also be taken into account and we will do what is necessary to take them into account and keep you informed if necessary.
+
+You can already browse our moodle pages, which contain all the information you need to prepare and organise your exam.
+https://moodle.epfl.ch/course/view.php?id=16420
+
+Best
+
+CePro
+`,
+            to: "{{registrant.email}}",
+            cc: "cepro-exams@epfl.ch",
+            replyTo: "",
+        },
+    },
+
+    crep_printing_confirmation: {
+        name: "Exam printing service subscription confirmation (CREP)",
+        placeholders: [
+            { token: "attentionPrefix", desc: "Subject prefix when attention required (computed)" },
+            { token: "attentionBlock", desc: "Warning/error block, empty if none (computed)" },
+            { token: "course", desc: "Course label" },
+            { token: "examDate", desc: "Exam date" },
+            { token: "desiredDate", desc: "Desired delivery date" },
+            { token: "contact", desc: "Contact (firstname lastname (email))" },
+            { token: "authorizedPersonsLine", desc: "Authorized persons line, empty if none (computed)" },
+            { token: "files", desc: "Uploaded files names" },
+            { token: "remarkLine", desc: "Additional remarks line, empty if none (computed)" },
+            { token: "registrant.email", desc: "Registrant email (recipient)" },
+        ],
+        defaults: {
+            subject: "{{attentionPrefix}}CePro - Exam printing service subscription confirmation",
+            body: `
+Hello,
+Your subscription to our exam printing service has been registered:
+{{attentionBlock}}
+
+- Course: {{course}}
+- Exam date: {{examDate}}
+- Desired delivery date: {{desiredDate}}
+- Contact: {{contact}}
+{{authorizedPersonsLine}}
+- Files: {{files}}
+{{remarkLine}}`,
+            to: "{{registrant.email}}",
+            cc: "cepro-exams@epfl.ch",
+            replyTo: "",
+        },
+    },
+
+    exam_ready_to_print: {
+        name: "Exam ready to print (Repro notification)",
+        placeholders: [
+            { token: "examCode", desc: "Exam code (used in subject)" },
+            { token: "description", desc: "Exam description" },
+            { token: "examURL", desc: "Direct link to the exam in the app (computed)" },
+        ],
+        defaults: {
+            subject: "Exam {{examCode}} is ready to be printed",
+            body: `
+Hello,
+
+The exam {{description}} status has been set to "toPrint" in CREP.
+
+You can see the exam in the app directly by clicking on this link : {{examURL}}
+
+Best,
+CePro team
+`,
+            to: "examen.repro@epfl.ch",
+            cc: "",
+            replyTo: "",
+        },
+    },
+
+    exam_ready_to_pickup: {
+        name: "Exam ready to pick up (contact notification)",
+        placeholders: [
+            { token: "examCode", desc: "Exam code (used in subject)" },
+            { token: "description", desc: "Exam description" },
+            { token: "boxes", desc: "Number of boxes" },
+            { token: "contact.email", desc: "Contact email (recipient)" },
+            { token: "authorizedPersons", desc: "Authorized persons emails (CC recipient)" },
+        ],
+        defaults: {
+            subject: "Exam {{examCode}} is ready to be picked up",
+            body: `
+Hello,
+
+The exam {{description}} has been finished printing and is ready to be picked up at the Repro.
+Number of boxes : {{boxes}}
+
+Click on this link to find where the Repro is located : https://plan.epfl.ch/?room=%253DBP%200243
+Click on this link to see the Repro's opening hours : https://www.epfl.ch/campus/services/repro/fr/contacts/#ancre2
+
+Best,
+CePro team
+`,
+            to: "{{contact.email}}",
+            cc: "{{authorizedPersons}}",
+            replyTo: "examen.repro@epfl.ch",
+        },
+    },
+};
+
+export type TemplateContext = Record<string, string | number | null | undefined>;
+
+// Replace every {{token}} occurrence with its value from the context.
+// Unknown tokens (or null/undefined values) resolve to an empty string.
+export function renderString(template: string, context: TemplateContext): string {
+    return template.replace(/{{\s*([\w.]+)\s*}}/g, (_match, token: string) => {
+        const value = context[token];
+        return value === null || value === undefined ? "" : String(value);
+    });
+}

--- a/app/lib/emailTemplates.ts
+++ b/app/lib/emailTemplates.ts
@@ -4,6 +4,7 @@ export type Placeholder = {
 };
 
 export type TemplateDefinition = {
+    section: string;
     name: string;
     placeholders: Placeholder[];
     defaults: {
@@ -15,14 +16,9 @@ export type TemplateDefinition = {
     };
 };
 
-export type EmailTemplateKey =
-    | "exam_services_confirmation"
-    | "crep_printing_confirmation"
-    | "exam_ready_to_print"
-    | "exam_ready_to_pickup";
-
-export const EMAIL_TEMPLATES: Record<EmailTemplateKey, TemplateDefinition> = {
+export const EMAIL_TEMPLATES = {
     exam_services_confirmation: {
+        section: "CEREAL",
         name: "Exam services subscription confirmation",
         placeholders: [
             { token: "course", desc: "Course code" },
@@ -68,7 +64,8 @@ CePro
     },
 
     crep_printing_confirmation: {
-        name: "Exam printing service subscription confirmation (CREP)",
+        section: "CREP",
+        name: "Exam printing service subscription confirmation",
         placeholders: [
             { token: "attentionPrefix", desc: "Subject prefix when attention required (computed)" },
             { token: "attentionBlock", desc: "Warning/error block, empty if none (computed)" },
@@ -102,7 +99,8 @@ Your subscription to our exam printing service has been registered:
     },
 
     exam_ready_to_print: {
-        name: "Exam ready to print (Repro notification)",
+        section: "CREP",
+        name: "Exam ready to print",
         placeholders: [
             { token: "examCode", desc: "Exam code (used in subject)" },
             { token: "description", desc: "Exam description" },
@@ -127,7 +125,8 @@ CePro team
     },
 
     exam_ready_to_pickup: {
-        name: "Exam ready to pick up (contact notification)",
+        section: "CREP",
+        name: "Exam ready to pick up",
         placeholders: [
             { token: "examCode", desc: "Exam code (used in subject)" },
             { token: "description", desc: "Exam description" },
@@ -155,6 +154,10 @@ CePro team
         },
     },
 };
+
+// Keys are derived from the registry, so adding or removing a template is a
+// single edit to EMAIL_TEMPLATES above (no separate union to keep in sync).
+export type EmailTemplateKey = keyof typeof EMAIL_TEMPLATES;
 
 export type TemplateContext = Record<string, string | number | null | undefined>;
 

--- a/app/lib/mail.ts
+++ b/app/lib/mail.ts
@@ -1,6 +1,13 @@
 'use server';
 
 import nodemailer from 'nodemailer';
+import { getEmailTemplate } from '@/app/lib/database';
+import {
+    EMAIL_TEMPLATES,
+    EmailTemplateKey,
+    TemplateContext,
+    renderString,
+} from '@/app/lib/emailTemplates';
 
 function getMailSubjectPrefix() {
     return process.env.CEREAL_ENV === 'test' ? 'TEST - ' : '';
@@ -25,4 +32,21 @@ export async function sendMail(to: string, subject: string, content: string, cc:
         cc: cc,
         replyTo: replyTo
     });
+}
+
+/* Send one of the admin-customizable emails. The template (subject, body,
+recipients) is loaded from the DB and falls back to the defaults defined in
+the registry if the row is missing. All {{token}} placeholders are resolved
+from the provided context. */
+export async function sendTemplatedMail(key: EmailTemplateKey, context: TemplateContext) {
+    const defaults = EMAIL_TEMPLATES[key].defaults;
+    const template = await getEmailTemplate(key);
+
+    const subject = renderString(template?.subject ?? defaults.subject, context);
+    const body = renderString(template?.body ?? defaults.body, context);
+    const to = renderString(template?.recipients_to ?? defaults.to, context);
+    const cc = renderString(template?.recipients_cc ?? defaults.cc, context);
+    const replyTo = renderString(template?.reply_to ?? defaults.replyTo, context);
+
+    return sendMail(to, subject, body, cc, replyTo || undefined);
 }

--- a/types/emailTemplate.ts
+++ b/types/emailTemplate.ts
@@ -1,6 +1,7 @@
 export type EmailTemplate = {
     id: number;
     template_key: string;
+    section: string;
     name: string;
     subject: string;
     body: string;

--- a/types/emailTemplate.ts
+++ b/types/emailTemplate.ts
@@ -1,0 +1,10 @@
+export type EmailTemplate = {
+    id: number;
+    template_key: string;
+    name: string;
+    subject: string;
+    body: string;
+    recipients_to: string;
+    recipients_cc: string;
+    reply_to: string;
+}


### PR DESCRIPTION
The 4 emails that are sent by the app are now fully customizable, using a new `email_template` table.

- On the `/admin` page, a new tab called `Emails`, where users can customize email subject, content, who is the email sent to, ...
- Placeholders feature for things like user name, files name, dates, ...
- The code is the truth source, no need to insert in the database, just add a new email template in the code
- Automatic synchronization between the database and the UI when loading the `/admin` page

Mainly made by AI but tested by me, please deal with caution.

Close #127 